### PR TITLE
Improved fix to subproof bug

### DIFF
--- a/src/aris-proof.c
+++ b/src/aris-proof.c
@@ -645,20 +645,6 @@ aris_proof_create_sentence (aris_proof * ap, sen_data * sd, int undo)
       gtk_widget_show (menu_item);
     }
   
-  // Initialize the sentence in validref_lines
-
-  line++;
-  if (validref_lines != NULL)
-    validref_lines[line] = 0;
-
-  // Reallocate validref_lines if number of lines is close to validref_lim
-
-  if (validref_lines!=NULL && validref_lim-line <= 10)
-  {
-    validref_lim+=100;
-    validref_lines = realloc(validref_lines,validref_lim*sizeof(int));
-  }
-
   return sen;
 }
 
@@ -732,21 +718,6 @@ aris_proof_create_new_sub (aris_proof * ap)
   if (!sen)
     return NULL;
 
-  top++;                            // Increment top of activesubp_stack
-
-  // Allocate stack if NULL
-
-  if (activesubp_stack == NULL )
-  {
-    activesubp_stack = malloc(100*sizeof(int));
-  }
-  else if (stack_lim - top <= 5)    // Reallocate stack if close to stack_lim
-  {
-    stack_lim+=25;
-    activesubp_stack = realloc(activesubp_stack,stack_lim*sizeof(int));
-  }
-  activesubp_stack[top] = line+1;   // Push the line to the stack
-
   sen_data_destroy (sd);
 
   return sen;
@@ -781,21 +752,6 @@ aris_proof_end_sub (aris_proof * ap)
   sen =  aris_proof_create_sentence (ap, sd, 1);
   if (!sen)
     return NULL;
-
-  // Allocate validref_lines if NULL
-
-  if (validref_lines == NULL)
-  {
-    validref_lines = calloc(100,sizeof(int));
-  }
-
-  // Invalidate lines from the activesubp_stack 's top to the current line by setting to 1
-
-  for (int i = activesubp_stack[top]; i <= line; i++)
-    validref_lines[i] = 1;
-  
-  // Pop from activesubp_stack  
-  top--;  
 
   sen_data_destroy (sd);
 

--- a/src/aris.c
+++ b/src/aris.c
@@ -934,8 +934,5 @@ evaluate flag not specified in non-gui mode.\n");
 #endif
     }
 
-  free(validref_lines);
-  free(activesubp_stack);
-
   exit (EXIT_SUCCESS);
 }

--- a/src/sen-data.c
+++ b/src/sen-data.c
@@ -28,16 +28,6 @@
 #include "proof.h"
 #include "interop-isar.h"
 
-// Initializes Lists and Variables to disallow subproof referencing
-
-int * activesubp_stack = NULL;
-int * validref_lines = NULL;
-int top = -1;
-int line = 0;
-int validref_lim = 100;
-int stack_lim = 25;
-
-
 /* Initializes the sentence data.
  *  input:
  *    line_num - the line number to set to this sentence data.

--- a/src/sen-data.h
+++ b/src/sen-data.h
@@ -27,15 +27,6 @@
 
 #define SD(o) ((sen_data *) o)
 
-//Lists and Variables to disallow subproof referencing
-
-extern int * activesubp_stack;  // Keeps track of the line numbers of active subproof
-extern int * validref_lines;    // Keeps track of referenceable lines and updates them during traversal down the proof
-extern int top;                 // top of activesubp_stack
-extern int line;                // Line number of current line during downward traversal
-extern int validref_lim;        // Max size of validref_lines
-extern int stack_lim;           // Max size of stack
-
 // Different value types.
 
 enum VALUE_TYPES {

--- a/src/sentence.c
+++ b/src/sentence.c
@@ -852,7 +852,7 @@ valid_ref (sen_parent * sp, sentence * sen, sentence * fcs_sen, int sen_line_num
               printf("Invalid reference to subproof");
             return 0;
           }
-        // Get the parent sentence of fcs_sen
+        // Get the parent sentence of s
         trav_up = ls_nth(sp->everything, s-2)->value;
         }
     }
@@ -870,7 +870,7 @@ valid_ref (sen_parent * sp, sentence * sen, sentence * fcs_sen, int sen_line_num
               return 0;
             }
           
-          // Get the parent sentence of fcs_sen
+          // Get the parent sentence of s
           trav_up = ls_nth(sp->everything, s-2)->value;
         }
     }


### PR DESCRIPTION
We get depths of the two sentences.
If the depth difference is greater than or equal to 2, it's invalid. 
If it's 1, we check if the focused sentence appears just after the subproof ends and allow it if so. 
If the difference is zero, we ensure that there is no sentence of lesser depth between the two, if there isn't it's a valid reference.