### PR TITLE
feat: validate file content on loading

### DIFF
--- a/qt/auxconnector.cpp
+++ b/qt/auxconnector.cpp
@@ -96,6 +96,11 @@ void auxConnector::importProof(const QString &name, ProofData *pd, const Connect
 
     proof_t *proof = aio_open(file_name);
 
+    if (!proof)
+        qDebug() << "Failed to import proof";
+        free(file_name);
+        return;
+
     item_t *pf_itr;
     int ref_num = 0, ev_conc = -1, ev_itr;
     short *refs;

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -293,11 +293,16 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
     memcpy(file_name, name.toStdString().c_str(), name.size());
 
     cProof = aio_open((const char *) file_name);
-    if (cProof)
-        qDebug() << "File Opened Successfully";
+    
     if (file_name)
         free(file_name);
 
+    if (!cProof)
+        qDebug() << "Failed to open proof";
+        return;
+
+    qDebug() << "File Opened Successfully";
+        
     reverseMapInit();
     int s = openTo->lines().size();
     for (int i = 0; i < s; i++)

--- a/src/aio.c
+++ b/src/aio.c
@@ -660,6 +660,113 @@ aio_save (proof_t * proof, const char * file_name)
     return 0;
 }
 
+/* Computes the indices arrays for every sen_data in a proof.
+ *  input:
+ *    proof - the proof for which to compute the indices.
+ *  output:
+ *    0 on success, -1 on error.
+ */
+static int
+aio_compute_indices (proof_t * proof)
+{
+    item_t * itr, * prev_itr;
+    int i;
+
+    prev_itr = NULL;
+    for (itr = proof->everything->head; itr; itr = itr->next)
+    {
+        sen_data * sd = (sen_data *) itr->value;
+        int depth = sd->depth;
+        int ln    = sd->line_num;
+
+        IF_FREE(sd->indices);
+
+        sd->indices = (int *) calloc (depth + 1, sizeof (int));
+        if (!sd->indices)
+            XML_ERR (AEC_MEM);
+
+        i = 0;
+        if (!sd->premise && prev_itr != NULL)
+        {
+            sen_data * prev_sd = (sen_data *) prev_itr->value;
+            int copy_end = (prev_sd->depth < depth) ? prev_sd->depth : depth;
+
+            for (i = 0; i < copy_end; i++)
+                sd->indices[i] = prev_sd->indices[i];
+
+            if (sd->subproof)
+                sd->indices[i++] = ln;
+        }
+        sd->indices[i] = -1;
+
+        prev_itr = itr;
+    }
+    return 0;
+}
+
+/* Validates a proof loaded from a file.
+ *  input:
+ *    proof - the proof to validate.
+ *  output:
+ *    0 on success, -1 on error.
+*/
+
+static int
+aio_validate_proof (proof_t * proof)
+{
+    if (!proof || !proof->everything)
+        return -1;
+
+    item_t * itr;
+
+    for (itr = proof->everything->head; itr; itr = itr->next)
+    {
+        sen_data * sd = (sen_data *) itr->value;
+        int i;
+        
+        /* premises and subproof starters cannot have references. */
+        if ((sd->premise || sd->subproof)
+            && sd->refs && sd->refs[0] != REF_END)
+            XML_ERR (-1);
+
+        if (sd->premise || sd->subproof)
+            continue;
+
+        /* rule index must be in [0, NUM_RULES-1]. */
+        if (sd->rule < 0 || sd->rule >= NUM_RULES)
+            XML_ERR (-1);
+
+        if (!sd->refs)
+            continue;
+
+        /* every reference must be valid. */
+        for (i = 0; sd->refs[i] != REF_END; i++)
+        {
+            int ref_line = (int) sd->refs[i];
+            sen_data * ref_sd = NULL;
+            item_t * ref_itr;
+
+            for (ref_itr = proof->everything->head;
+                 ref_itr; ref_itr = ref_itr->next)
+            {
+                sen_data * cand = (sen_data *) ref_itr->value;
+                if (cand->line_num == ref_line)
+                {
+                    ref_sd = cand;
+                    break;
+                }
+            }
+
+            if (!ref_sd)
+                XML_ERR (-1);
+
+            if (sen_data_can_select_as_ref (sd, ref_sd) == 0)
+                XML_ERR (-1);
+        }
+    }
+    return 0;
+}
+
 /* Opens a proof.
  *  input:
  *    file_name - the name of the file to open.
@@ -899,6 +1006,12 @@ aio_open (const char * file_name)
     }
 
     xmlFreeTextReader (xml);
+
+    if (aio_compute_indices (proof) < 0)
+        XML_ERR (NULL);
+        
+    if (aio_validate_proof (proof) < 0)
+        XML_ERR (NULL);
 
     return proof;
 }

--- a/src/aio.c
+++ b/src/aio.c
@@ -683,7 +683,7 @@ aio_compute_indices (proof_t * proof)
 
         sd->indices = (int *) calloc (depth + 1, sizeof (int));
         if (!sd->indices)
-            XML_ERR (AEC_MEM);
+            return -1;
 
         i = 0;
         if (!sd->premise && prev_itr != NULL)
@@ -727,14 +727,14 @@ aio_validate_proof (proof_t * proof)
         /* premises and subproof starters cannot have references. */
         if ((sd->premise || sd->subproof)
             && sd->refs && sd->refs[0] != REF_END)
-            XML_ERR (-1);
+            return -1;
 
         if (sd->premise || sd->subproof)
             continue;
 
         /* rule index must be in [0, NUM_RULES-1]. */
         if (sd->rule < 0 || sd->rule >= NUM_RULES)
-            XML_ERR (-1);
+            return -1;
 
         if (!sd->refs)
             continue;
@@ -758,10 +758,10 @@ aio_validate_proof (proof_t * proof)
             }
 
             if (!ref_sd)
-                XML_ERR (-1);
+                return -1;
 
             if (sen_data_can_select_as_ref (sd, ref_sd) == 0)
-                XML_ERR (-1);
+                return -1;
         }
     }
     return 0;


### PR DESCRIPTION
Fixes #24 

### Problem:
While loading a `.tle` file from GUI, the integrity of the proof is not checked, this can lead to several errors creeping in, which can be achieved through a corrupted proof file by editing XML tags. 

The `aio_open()` function is responsible for parsing the xml into `proof_t`. It parsed the xml with no validation checks. Anyone could edit the `.tle` file to produce situations like:

- A conclusion on line 5 referring to line 8 (forward reference)
- A conclusion referring a line inside a closed subproof it has no access to
- A premise or subproof assumption carrying references
- A rule index outside the valid range of rules_list[]

### Solution
Two new functions are added to `aio.c`, called at the tail of `aio_open()` after XML parsing completes:

1. `aio_compute_indices(proof_t *)`:  Computes each sentences indices, similar to the logic used by `sentence_init()` function in `sentence.c`. This is required for validation using the `sen_data_can_select_as_ref()` function.

2. `aio_validate_proof(proof_t *)`: It makes the following checks:
    1. Premises and subproof assumption lines must have no references
    2. Every conclusion's rule index is in [0, NUM_RULES-1].
    3. Every reference points to a line that exists, there shouldn't be forward referencing, and referenced line is in the scope ( enforced by reusing `sen_data_can_select_as_ref()` function).

### Build details:
There are no build errors (built qt using cmake).

### Testing

I picked up doc/proofs/equivalence/pf-id.tle and edited the xml to corrupt it and test it. On line 18, I set l=999 and r=99 to test for forward references and out of bound conclusion's rule index.
This is the xml file used:

```
<?xml version="1.0"?>
<proof mode="standard" version="1.0">
 <goals>
  <goal t="A"/>
  <goal t="P(a)"/>
  <goal t="P(a) &amp; f(a) : b"/>
  <goal t="@x(R(x) &amp; H(x))"/>
  <goal t="P(a) | P(a)"/>
  <goal t="@x(R(x) &amp; H(x)) | @x(R(x) &amp; H(x))"/>
 </goals>
 <premises>
  <entry n="1" t="A &amp; A ;; Let's start with the simple one"/>
  <entry n="2" t="P(a) &amp; P(a) ;; And now a little more complex"/>
  <entry n="3" t="P(a) &amp; (f(a) : b &amp; f(a) : b &amp; f(a) : b)  ;; And the fun one."/>
  <entry n="4" t="@x(R(x) &amp; R(x) &amp; H(x))  ;; And one with quantifiers."/>
 </premises>
 <conclusions>
  <entry n="5" l="999" r="99" d="0" t="A"/>
  <entry n="6" l="12" r="2" d="0" t="P(a)"/>
  <entry n="7" l="12" r="3" d="0" t="P(a) &amp; f(a) : b"/>
  <entry n="8" l="12" r="4" d="0" t="@x(R(x) &amp; H(x))"/>
  <entry n="9" l="12" r="6" d="0" t="P(a) | P(a)"/>
  <entry n="10" l="12" r="8" d="0" t="@x(R(x) &amp; H(x)) | @x(R(x) &amp; H(x))"/>
 </conclusions>
</proof>
```
#### Before:
<img width="1888" height="1125" alt="image" src="https://github.com/user-attachments/assets/d2d34163-f2dc-408a-b9a0-ffb53712e454" />
(See line 5)

#### After:
<img width="866" height="629" alt="image" src="https://github.com/user-attachments/assets/2e3c189b-9469-487e-a4f8-cc0c38a23673" />
(The program throws XML Error when loading a corrupt `.tle` file)