### PR TITLE
blank line and white screen issue

### DIFF
--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -455,16 +455,28 @@ Item {
 
                     Action {
                         text: "Remove this Line"
-                        enabled: !((premiseCount == listView.count)
-                                   && (listView.count == 1))
+                        enabled: true 
 
                         onTriggered: {
-                            if (type === "premise")
-                                premiseCount--
-                            var i = index
-                            theData.removeLineAt(index)
-                            proofModel.updateLines()
-                            proofModel.updateRefs(i, false)
+                            if (listView.count > 1) {
+                              
+                                if (type === "premise")
+                                    premiseCount--
+                                
+                                var i = index
+                                theData.removeLineAt(index)
+                                proofModel.updateLines()
+                                proofModel.updateRefs(i, false)
+                            } else {
+                                
+                                theData.removeLineAt(0)
+                                theData.insertLine(0, 1, "", "premise", false, false, false, 0, [-1])   
+                                premiseCount = 1
+                                proofModel.updateLines()
+                                listView.currentIndex = 0
+                                console.log("Goal 3: Last line reset to prevent blank screen crash.")
+                            }
+                            
                             cConnector.evalText = "Evaluate Proof"
                         }
                     }

--- a/qt/auxconnector.cpp
+++ b/qt/auxconnector.cpp
@@ -96,10 +96,11 @@ void auxConnector::importProof(const QString &name, ProofData *pd, const Connect
 
     proof_t *proof = aio_open(file_name);
 
-    if (!proof)
+    if (!proof) {
         qDebug() << "Failed to import proof";
         free(file_name);
         return;
+    }
 
     item_t *pf_itr;
     int ref_num = 0, ev_conc = -1, ev_itr;
@@ -107,7 +108,14 @@ void auxConnector::importProof(const QString &name, ProofData *pd, const Connect
 
     refs = (short *) calloc (proof->everything->num_stuff, sizeof(int));
 
-    int num_ins = 1;
+    while (pd->lines().size() > 0) {
+        pd->removeLineAt(0);
+    }
+    
+    // 2. TELL THE UI THE LIST IS NOW EMPTY 
+    pm->updateLines(); 
+
+    int num_ins = 0;
     for (pf_itr =(item_t *) proof->everything->head; pf_itr != NULL; pf_itr = pf_itr->next){
         sen_data *sd;
         char *pf_text;

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -297,9 +297,10 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
     if (file_name)
         free(file_name);
 
-    if (!cProof)
+    if (!cProof) {
         qDebug() << "Failed to open proof";
         return;
+    }
 
     qDebug() << "File Opened Successfully";
         

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -175,6 +175,9 @@ ApplicationWindow {
         onAccepted: {
             isExtFile = true
             computePremise = true
+            if (premiseCount === 1) {
+                premiseCount = 0
+            }
             auxConnector.importProof(selectedFile, theData, cConnector,
                                      proofModel)
         }


### PR DESCRIPTION
This PR addresses several small issues discovered during the last merge, focusing on syntax correction, import formatting, and editor stability.

**Key Changes**

**1. Syntax & Logic Fixes**: Corrected bracket errors in multiple classes that were preventing valid proofs from being imported correctly. Changes were made in qt/auxConnector.cpp and qt/connector.cpp 

**2. Import Formatting**: Fixed a bug where a blank line was erroneously inserted at the beginning of an imported proof.

**3. Editor UX (Empty State Handling)**: Resolved an issue where deleting all lines in a proof left the editor in an unrecoverable state. The editor now automatically generates a standard default line when the last remaining line is deleted, removing the need for a page reload.

**4. Import State Reset**: Resolved a major issue where importing a new proof after deleting a previous one would only result in a partial import. The system now correctly imports the entire proof regardless of previous editor states.

**Impact**

These changes ensure that the proof import pipeline is functional and that the editor remains interactive even after a user clears all existing content.

**Issues captures**
<img width="1470" height="885" alt="valid tle file" src="https://github.com/user-attachments/assets/3cd3ccdd-800f-490f-ba19-ed73bacda6b2" />

<img width="1468" height="777" alt="empty screen issue" src="https://github.com/user-attachments/assets/847b5178-c11d-4fcb-a369-7c1896b271bb" />

<img width="1464" height="880" alt="Ghostline issue" src="https://github.com/user-attachments/assets/2a81dd42-ab31-4628-a381-3d42a4c33a85" />

<img width="1463" height="882" alt="import issue after deleting imported proof" src="https://github.com/user-attachments/assets/2a3fff7b-4bc7-44a6-9f2e-5232aa0785e4" />


**The Problem**: Deleting the last line reduced the model count to 0, causing a QML engine stall ("White Screen") because the ListView had no delegate to render or focus.

Fix: Modified the Remove this Line action in ProofArea.qml to prevent the count from ever hitting zero.

Method: Added a conditional check:

                If lines > 1: Deletes the line normally.
                
                If line == 1: Executes a Remove-and-Reinsert sequence. It clears the "dirty" line and immediately inserts a fresh,       empty "Premise."

Result: The UI stays active, and the "Remove" button effectively becomes a "Reset" button for the final line, ensuring the app remains stable and usable.

**The Problem**: When importing a new proof, the first line from the previous session (or a default blank line) would persist at the top, causing the imported file to start at Line 2 (the "Ghost Line" effect).

The Fix: Implemented a mandatory Model Clear at the start of the importProof function in auxconnector.cpp.

Method:  Total Purge:
           
                Used a while loop to remove every existing line from the ProofData container before the import begins.

UI Sync: 
               
               Explicitly called pm->updateLines() after the purge to tell the QML View the list is empty.

Zero-Index Start:
 
                Reset the insertion counter (num_ins = 0) to ensure the new proof data begins strictly at the first row.

Result: Imported proofs now consistently start at Line 1 with no leftover data from the previous state.




