### PR TITLE
fix: fix indentation error introduced in #30

### DIFF
--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -297,9 +297,10 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
     if (file_name)
         free(file_name);
 
-    if (!cProof)
+    if (!cProof) {
         qDebug() << "Failed to open proof";
         return;
+    }
 
     qDebug() << "File Opened Successfully";
         


### PR DESCRIPTION
Following the discussion on the merged PR #30 , I looked into the issue.
The previous commit introduced indentation error due to missing braces around an if guard.

It has been fixed and now tested on both corrupt and valid proofs.

<img width="823" height="245" alt="image" src="https://github.com/user-attachments/assets/151c0ada-c714-45a1-8beb-9798e3129d21" />

Thanks @khush3e for informing about the issue
https://github.com/kovzol/aris/pull/30#issuecomment-4035512108
