### PR TITLE
fix: fix toggle goals

### DIFF
--- a/qt/DrawerTools.qml
+++ b/qt/DrawerTools.qml
@@ -123,7 +123,10 @@ ToolBar {
             icon.color: darkMode ? "white" : "black"
 
             onClicked: {
-                goalDialogID.open()
+                if (goalDialogID.opened)
+                    goalDialogID.close()
+                else
+                    goalDialogID.open()
                 menuOptions.close()
             }
         }


### PR DESCRIPTION
### Problem
On hitting Toggle goals button from burger menu, it only opened the window, and didn't close it when the window was already open.

### Fix
This PR fixes it and actually toggles the Goals window based on its visibility