### PR TITLE
fix: pr label hidden on narrow windows

### DIFF
--- a/src/sentence.c
+++ b/src/sentence.c
@@ -185,6 +185,7 @@ sentence_gui_init (sentence * sen)
   sen->entry = gtk_text_view_new ();
   gtk_widget_set_hexpand (sen->entry, TRUE);
   gtk_widget_set_halign (sen->entry, GTK_ALIGN_FILL);
+  gtk_widget_set_size_request (sen->entry, 0, -1);
 
   sen->value = gtk_image_new_from_icon_name (sen_values[0], GTK_ICON_SIZE_MENU);
 
@@ -201,7 +202,10 @@ sentence_gui_init (sentence * sen)
   sen->rule_box = gtk_label_new (NULL);
   gtk_label_set_justify (GTK_LABEL (sen->rule_box), GTK_JUSTIFY_FILL);
   gtk_label_set_width_chars (GTK_LABEL (sen->rule_box), 2);
-
+  gtk_widget_set_hexpand(sen->rule_box, FALSE);
+  gtk_widget_set_halign(sen->rule_box, GTK_ALIGN_END);
+  gtk_widget_set_size_request(sen->rule_box, 30, -1);
+  
   gtk_grid_attach (GTK_GRID (sen->panel), sen->rule_box, left++, 0, 1, 1);
 
   sen->mark = NULL;


### PR DESCRIPTION
## Problem
The `pr` label was being pushed off-screen when the proof window was narrow, making it invisible to users.

## Root Cause
`sen->entry` had `hexpand=TRUE` with no minimum width constraint, causing it to consume all available space and clip `rule_box`.

## Fix
- Added `hexpand=FALSE` + `GTK_ALIGN_END` on `rule_box`
- Added `size_request` constraints on both `entry` and `rule_box`

## Screenshots
**Before:**
![before-gnu-aris](https://github.com/user-attachments/assets/20206bcf-4606-48fb-8081-984a59124b9f)

**After:**
![after-gnu-aris-fix](https://github.com/user-attachments/assets/3180ca88-c821-4d6e-babb-761980f18e3b)