### PR TITLE
fix: fix cmake build errors due to unsupported cmake commands and arguments

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -79,8 +79,10 @@ qt_add_qml_module(aris-qt
         assets/icons/arisqt/512x512/eval.png
 )
 
-qt_add_translations(TARGETS aris-qt
-    TS_OUTPUT_DIRECTORY i18n)
+qt_add_translations(aris-qt
+    TS_FILES
+        i18n/aris-qt_ar.ts
+        i18n/aris-qt_en.ts)
 
 set_target_properties(aris-qt PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -7,8 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_definitions(WITH_CMAKE)
 
 find_package(Qt6 REQUIRED COMPONENTS Quick Widgets QuickControls2 LinguistTools)
-qt_standard_project_setup(REQUIRES 6.0
-    I18N_TRANSLATED_LANGUAGES ar)
+set(Qt6_FIND_VERSION_MIN 6.0)
 find_package(LibXml2 REQUIRED)
 
 add_executable(aris-qt


### PR DESCRIPTION


This issue was introduced in PR #34

### Problem

1. The project requires Qt 6.0 as minimum version, but in PR #34 , the keywords used in arguments of `qt_add_translations()` command are not supported by version 6.0. The keywords used were:

   1. `TARGETS`: Before 6.7, the command only accepted first argument as target. So running `cmake --build` with Qt version less than 6.7 throws error as "Targets" keyword is not recognized as a valid target. [[source: docs](https://doc.qt.io/qt-6/qtlinguist-cmake-qt-add-translations.html#qt-add-translations-before-qt-6-7)]
   2. `TS_OUTPUT_DIRECTORY`: This keyword was introduced in version 6.9. 

   Hence this command needs minimum version 6.9 to work as intended

2.  The PR replaced `set(Qt6_FIND_VERSION_MIN 6.0)` with `qt_standard_project_setup(REQUIRES 6.0)` which was introduced in 6.3. Furthermore the argument `I18N_TRANSLATED_LANGUAGES` was introduced in 6.7, thus unsupported on version 6.0

### Fix

This PR replaces the unsupported commands and arguments, with those supported by minimum version requirement 6.0 

### Before:
<img width="1516" height="871" alt="image" src="https://github.com/user-attachments/assets/47be1520-26fd-4882-8065-584fac4d21b3" />

### After:
<img width="1516" height="871" alt="image" src="https://github.com/user-attachments/assets/3286ac15-040c-4cb7-9a37-5f2f491e230a" />

_This build was run with Qt version 6.4.2_