### PR TITLE
Fix memory leaks in sentence_update_line_no loop

### DIFF
--- a/src/sentence.c
+++ b/src/sentence.c
@@ -381,20 +381,29 @@ sentence_update_line_no (sentence * sen, int new)
       const char * label =
         gtk_menu_item_get_label (GTK_MENU_ITEM (gl->data));
 
+      if (!label)
+        continue;
+
       int chk, line_num, lbl_len;
       char * file_name;
 
       lbl_len = strlen (label);
 
-      file_name = (char *) calloc (lbl_len, sizeof (char));
+      file_name = (char *) calloc (lbl_len + 1, sizeof (char));
       CHECK_ALLOC (file_name, AEC_MEM);
 
       chk = sscanf (label, "%i - %s", &line_num, file_name);
       if (chk != 2)
-        continue;
+        {
+          free (file_name);
+          continue;
+        }
 
       if (line_num < old)
-        continue;
+        {
+          free (file_name);
+          continue;
+        }
 
       line_num = new;
 
@@ -409,6 +418,7 @@ sentence_update_line_no (sentence * sen, int new)
       free (file_name);
 
       gtk_menu_item_set_label (GTK_MENU_ITEM (gl->data), new_label);
+      free (new_label);
     }
 
   return 0;


### PR DESCRIPTION
**Fixes: #45** 
This PR fixes memory leaks in the line relabeling path inside sentence_update_line_no in `sentence.c`
### Changes made

- Added a null check for label before calling [strlen](vscode-file://vscode-app/c:/Users/abhis/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Allocated file_name with lbl_len + 1 bytes to ensure safe null termination.
- Freed file_name before early continue paths:
- when sscanf parsing fails
- when line_num < old
- Freed new_label after gtk_menu_item_set_label, since GTK copies the string.

### Why this matters
The previous loop leaked memory in common UI update paths (especially during repeated sentence renumbering), causing cumulative memory growth over long editing sessions.

### Expected impact
- Reduced cumulative memory usage.
- Improved runtime stability over prolonged use.
- No intended user-visible behavior changes.

### Scope
- Only `sentence.c` was modified.
- No architectural changes.
- Low-risk, localized fix.