### PR TITLE
Improve clarity of error messages in sentence validation

### DIFF
--- a/src/sen-data.c
+++ b/src/sen-data.c
@@ -297,19 +297,20 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
     case 0:
         break;
     case -2:
-        return _("The sentence has mismatched parenthesis.");
+        return _("Mismatched parentheses. Please check opening and closing brackets.");
     case -3:
-        return _("The sentence has invalid connectives.");
+        return _("Invalid logical operator. For example, avoid '&&' and use logical symbols like ∧ (AND) or ∨ (OR).");
     case -4:
-        return _("The sentence has invalid quantifiers.");
+        return _("Invalid quantifier usage. Please check symbols like ∀ (for all) or ∃ (exists).");
     case -5:
-        return _("The sentence has syntactical errors.");
+        return _("Syntax error in the sentence. Please check the structure and logical format.");
     }
 
     *ret_val = VALUE_TYPE_BLANK;
 
     if (sd->premise || sd->subproof)
     {
+
         *ret_val = VALUE_TYPE_TRUE;
         return CORRECT;
     }


### PR DESCRIPTION
This PR proposes an improvement to error message clarity for better user experience.

Motivation:
The current error messages are generic and may be unclear for beginners. This change makes them more descriptive and helpful.

Changes:
- Clarified messages for invalid logical operators
- Improved explanations for parentheses and syntax errors
- Added better guidance for beginners

These improvements enhance usability and help users better understand and fix their input errors.