### PR TITLE
Set C/C++ standards version

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.16)
 project(aris-qt VERSION 0.1 LANGUAGES C CXX)
 
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_definitions(WITH_CMAKE)
 

--- a/src/process-main.c
+++ b/src/process-main.c
@@ -27,7 +27,7 @@ process (unsigned char * conc, vec_t * prems, const char * rule, vec_t * vars,
 
     conclusion = conc;
 
-    char * infer, * equiv, * quant, * misc, * bool;
+    char * infer, * equiv, * quant, * misc, * bool_;
 
     infer = process_inference (conclusion, prems, rule);
     if (!infer)
@@ -42,11 +42,11 @@ process (unsigned char * conc, vec_t * prems, const char * rule, vec_t * vars,
     if (strncmp (equiv, NOT_MINE, 28))
         return equiv;
 
-    bool = process_bool (conclusion, prems, rule);
-    if (!bool)
+    bool_ = process_bool (conclusion, prems, rule);
+    if (!bool_)
         return NULL;
-    if (strncmp (bool, NOT_MINE, 28))
-        return bool;
+    if (strncmp (bool_, NOT_MINE, 28))
+        return bool_;
 
     quant = process_quantifiers (conclusion, prems, rule, vars);
     if (!quant)


### PR DESCRIPTION
Compiling the Qt app with a modern compiler (gcc>=15) fails because `bool` is a keyword in the default -std=c23. https://github.com/kovzol/aris/blob/1f3a215de340609bcf4b41e098d5d969fdc7236c/src/process-main.c#L30 This PR renames the variable to `bool_` (as a good practice) and pins the standards version so the code compiles even if there's a similar breaking change.