### PR TITLE
Fix qt dockerfile and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ notice and this notice are preserved.
   - [gtk version](#gtk-version)
   - [qt version](#qt-version)
   - [WebAssembly](#webassembly)
+  - [Docker](#docker)
 - [Contributing Guide](#contributing-guide)
   - [Getting Started](#getting-started)
   - [How to Contribute](#how-to-contribute)
@@ -156,6 +157,35 @@ Now, run:
 python -m http.server 8000
 ```
 The project can be found at `http://0.0.0.0:8000/` .
+
+### Docker
+
+Dockerfiles for all three builds are in the `docker/` directory.
+
+#### Build
+
+```
+docker build -f docker/gtk.Dockerfile  -t aris-gtk  .
+docker build -f docker/qt.Dockerfile   -t aris-qt   .
+docker build -f docker/wasm.Dockerfile -t aris-wasm .
+```
+
+#### Run
+
+WASM (serves at `http://localhost:8000`):
+```
+docker run --rm -p 8000:8000 aris-wasm
+```
+
+GTK and Qt are GUI apps and need X11 forwarding to display on the host:
+```
+docker run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix aris-gtk
+docker run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix aris-qt
+```
+
+For software rendering (if OpenGL is unavailable), add `-e QT_QUICK_BACKEND=software` to the Qt command.
+
+**Note for macOS:** Running GUI containers requires an X11 display server like [XQuartz](https://www.xquartz.org/).
 
 
 ### Contributing Guide

--- a/docker/qt.Dockerfile
+++ b/docker/qt.Dockerfile
@@ -25,8 +25,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libqt6quick6 libqt6quickcontrols2-6 \
     qml6-module-qtquick qml6-module-qtquick-controls \
     qml6-module-qtquick-layouts qml6-module-qtquick-window \
+    qml6-module-qtquick-dialogs qml6-module-qtqml-workerscript \
+    qml6-module-qtquick-templates \
+    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+    libxcb-render-util0 libxcb-xfixes0 libxcb-xinerama0 \
+    libxcb-shape0 libxkbcommon-x11-0 libxcb-cursor0 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /src/build-qt/aris-qt /usr/local/bin/aris-qt
+COPY --from=build /src/build-qt/aris-qt /opt/aris-qt/aris-qt
+COPY --from=build /src/build-qt/arisqt/ /opt/aris-qt/arisqt/
 
-ENTRYPOINT ["aris-qt"]
+WORKDIR /opt/aris-qt
+ENTRYPOINT ["./aris-qt"]


### PR DESCRIPTION
Fix for:
```
QQmlApplicationEngine failed to load component
file:///arisqt/main.qml: No such file or directory
```

Also updated README.