### PR TITLE
Fix WASM use-after-free by capturing pointers by value

### DIFF
--- a/qt/auxconnector.cpp
+++ b/qt/auxconnector.cpp
@@ -300,7 +300,7 @@ void auxConnector::importProof(const QString &name, ProofData *pd, const Connect
  */
 void auxConnector::wasmImportProof(ProofData *pd, const Connector *c, ProofModel *pm)
 {
-    auto fileContentReady = [this, &c, &pd, &pm](const QString &fileName, const QByteArray &fileContent) {
+    auto fileContentReady = [this, c, pd, pm](const QString &fileName, const QByteArray &fileContent) {
         if (fileName.isEmpty()) {
             qDebug() << "No file was selected" ;
             emit importFinished(false);
@@ -358,7 +358,7 @@ void auxConnector::importProofWithMode(const QString &name, ProofData *pd, const
 
 void auxConnector::wasmImportProofWithMode(ProofData *pd, const Connector *c, ProofModel *pm, int mode)
 {
-    auto fileContentReady = [this, &c, &pd, &pm, mode](const QString &fileName, const QByteArray &fileContent) {
+    auto fileContentReady = [this, c, pd, pm, mode](const QString &fileName, const QByteArray &fileContent) {
         if (fileName.isEmpty()) {
             qDebug() << "No file was selected" ;
             emit importFinished(false);

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -443,7 +443,7 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
  */
 void Connector::wasmOpenProof(ProofData *open, GoalData *gls)
 {
-    auto fileContentReady = [&open, this, &gls](const QString &fileName, const QByteArray &fileContent) {
+    auto fileContentReady = [open, this, gls](const QString &fileName, const QByteArray &fileContent) {
         if (fileName.isEmpty()) {
             qDebug() << "No file was selected" ;
         } else {


### PR DESCRIPTION
**Fixes** : #53

## Description

On WebAssembly, `QFileDialog::getOpenFileContent` returns immediately, executing the provided callback asynchronously.

In `connector.cpp` and `auxconnector.cpp`, the lambdas passed to this function capture pointer parameters by reference (`&open`, `&gls`, `&c`, `&pd`, `&pm`). By the time the async callback is invoked, the enclosing stack frame has been destroyed, resulting in dangling references and undefined behavior.

This patch fixes the issue by capturing these pointers by value. Since the pointed-to objects are long-lived Qt UI models that outlive the file dialog, capturing them by value is both safe and correct.


