### PR TITLE
 Core Engine Cleanup, Locale-Invariant Rule Selection, and UI Error Surfacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ doc/aris/*.html
 doc/aris.info
 doc/stamp-vti
 doc/version.texi
+
+# Personal editor config 
+.vscode/
+.DS_Store

--- a/qt/DrawerTools.qml
+++ b/qt/DrawerTools.qml
@@ -295,23 +295,23 @@ ToolBar {
 
                 MenuItem {
                     text: "English"
-                    onTriggered: settings.setLanguage("en")
+                    onTriggered: { settings.setLanguage("en"); appPrefs.language = "en" }
                 }
                 MenuItem {
                     text: "العربية"
-                    onTriggered: settings.setLanguage("ar")
+                    onTriggered: { settings.setLanguage("ar"); appPrefs.language = "ar" }
                 }
                 MenuItem {
                     text: "Deutsch"
-                    onTriggered: settings.setLanguage("de")
+                    onTriggered: { settings.setLanguage("de"); appPrefs.language = "de" }
                 }
                 MenuItem {
                     text: "Français"
-                    onTriggered: settings.setLanguage("fr")
+                    onTriggered: { settings.setLanguage("fr"); appPrefs.language = "fr" }
                 }
                 MenuItem {
                     text: "Magyar"
-                    onTriggered: settings.setLanguage("hu")
+                    onTriggered: { settings.setLanguage("hu"); appPrefs.language = "hu" }
                 }
             }
         }

--- a/qt/DrawerTools.qml
+++ b/qt/DrawerTools.qml
@@ -66,7 +66,6 @@ ToolBar {
                 if (Qt.platform.os === "wasm") {
                     isExtFile = true
                     cConnector.wasmOpenProof(theData, theGoals)
-                    computePremise = true
                 } else
                     fileDialogID.open()
 

--- a/qt/GoalLine.qml
+++ b/qt/GoalLine.qml
@@ -92,7 +92,12 @@ RowLayout {
             }
         }
 
-        onEditingFinished: model.text = text
+        onTextEdited: fileModified = true
+
+        onEditingFinished: {
+            if (model.text !== text) fileModified = true
+            model.text = text
+        }
     }
 
     Button {
@@ -115,6 +120,7 @@ RowLayout {
                 text: "Add Goal"
                 onTriggered: {
                     theGoals.insertgLine(index + 1, -2, false, "")
+                    fileModified = true
                 }
             }
 
@@ -123,6 +129,7 @@ RowLayout {
                 onTriggered: {
                     if (goalDataID.rowCount() > 1) {
                         theGoals.removegLineAt(index)
+                        fileModified = true
                     } else
                         console.log("Invalid Operation: Cannot remove all Lines")
                 }

--- a/qt/GoalLine.qml
+++ b/qt/GoalLine.qml
@@ -130,8 +130,10 @@ RowLayout {
                     if (goalDataID.rowCount() > 1) {
                         theGoals.removegLineAt(index)
                         fileModified = true
-                    } else
+                    } else {
                         console.log("Invalid Operation: Cannot remove all Lines")
+                        cConnector.evalText = "⚠ " + qsTr("Invalid Operation: At least one goal line must remain.")
+                    }
                 }
             }
         }

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -710,7 +710,7 @@ Item {
                 onActivated: {
                     editCombos = true
                     proofModel.setData(proofModel.index(indexx, 0),
-                                       currentIndex, 266)  // RuleCategoryRole
+                                       currentIndex, 265)  // RuleCategoryRole
                     asteriskID.visible = false
                 }
 
@@ -757,9 +757,11 @@ Item {
 
                 onActivated: {
                     editCombos = true
+                    proofModel.setData(proofModel.index(indexx, 0),
+                                       chooseID.currentIndex, 265)  // RuleCategoryRole
                     // Write the rule index integer (locale-invariant).
                     proofModel.setData(proofModel.index(indexx, 0),
-                                       currentIndex, 267)  // RuleIndexRole
+                                       currentIndex, 266)  // RuleIndexRole
                     asteriskID.visible = false
                 }
 

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -710,26 +710,14 @@ Item {
                 onActivated: {
                     editCombos = true
                     proofModel.setData(proofModel.index(indexx, 0),
-                                       conclusionRuleID.currentText, 258)
+                                       currentIndex, 266)  // RuleCategoryRole
                     asteriskID.visible = false
                 }
 
                 model: [qsTr("Inference"), qsTr("Equivalence"), qsTr("Predicate"), qsTr("Miscellaneous"), qsTr("Boolean")]
 
-                Component.onCompleted: {
-                    if (!editCombos) {
-                        if (combo2[0].includes(type))
-                            currentIndex = 0
-                        else if (combo2[1].includes(type))
-                            currentIndex = 1
-                        else if (combo2[2].includes(type))
-                            currentIndex = 2
-                        else if (combo2[3].includes(type))
-                            currentIndex = 3
-                        else
-                            currentIndex = 4
-                    }
-                }
+                // Bind currentIndex to the locale-invariant integer from the model.
+                currentIndex: !editCombos && model.ruleCategory >= 0 ? model.ruleCategory : currentIndex
             }
 
             // Second ComboBox to select rule
@@ -769,16 +757,16 @@ Item {
 
                 onActivated: {
                     editCombos = true
+                    // Write the rule index integer (locale-invariant).
                     proofModel.setData(proofModel.index(indexx, 0),
-                                       currentText, 258)
+                                       currentIndex, 267)  // RuleIndexRole
                     asteriskID.visible = false
                 }
 
-                onModelChanged: {
-                    if (!editCombos) {
-                        currentIndex = model.indexOf(type)
-                    }
-                }
+                // Bind currentIndex to the locale-invariant integer from the model.
+                // This binding survives language changes because it reads integers,
+                // not translated strings. When editCombos is true the user is editing.
+                currentIndex: !editCombos && model.ruleIndex >= 0 ? model.ruleIndex : currentIndex
 
                 model: combo2[chooseID.currentIndex]
             }

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -440,6 +440,18 @@ Item {
                 listView.currentIndex = temp
             }
 
+            // Restore stored integer role values when language change resets combobox models.
+            Connections {
+                target: settings
+                function onLanguageChanged() {
+                    if (model.ruleCategory >= 0)
+                        chooseID.currentIndex = model.ruleCategory
+                    if (model.ruleIndex >= 0)
+                        conclusionRuleID.currentIndex = model.ruleIndex
+                }
+            }
+
+
             RowLayout {
                 id: root_delegate
                 spacing: scaledSpacing
@@ -469,24 +481,28 @@ Item {
 
                 // Add this button's line to the current line's references
                 onClicked: {
-                    if (listView.currentIndex <= index)
+                    if (listView.currentIndex <= index) {
                         console.log("Invalid Operation : Can only reference to smaller line numbers")
-                    else if (proofModel.data(proofModel.index(
+                        cConnector.evalText = "⚠ " + qsTr("Invalid Operation: A proof line can only reference earlier line numbers.")
+                    } else if (proofModel.data(proofModel.index(
                                                  listView.currentIndex, 0),
-                                             257) === "premise")
+                                             257) === "premise") {
                         console.log("Invalid Operation: Current Line is a premise")
-                    else if (proofModel.data(proofModel.index(
+                        cConnector.evalText = "⚠ " + qsTr("Invalid Operation: Cannot assign inference rules or references to a premise.")
+                    } else if (proofModel.data(proofModel.index(
                                                  listView.currentIndex, 0),
-                                             260) === true)
+                                             260) === true) {
                         //|| proofModel.data(proofModel.index(listView.currentIndex,0),261) === true)
                         console.log("Invalid Operation: Subproof beginning")
-                    else if (proofModel.data(
+                        cConnector.evalText = "⚠ " + qsTr("Invalid Operation: Cannot modify or reference the start line of a subproof directly.")
+                    } else if (proofModel.data(
                                  proofModel.index(listView.currentIndex, 0),
                                  262) < model.ind && proofModel.data(
                                  proofModel.index(listView.currentIndex, 0),
-                                 261) === false)
+                                 261) === false) {
                         console.log("Invalid Operation: Invalid reference to subproof")
-                    else {
+                        cConnector.evalText = "⚠ " + qsTr("Invalid Operation: Cannot reference lines across closed subproof boundaries.")
+                    } else {
                         cConnector.evalText = "Evaluate Proof"
                             proofModel.clearErrors()
                         var array = Array.from(proofModel.data(
@@ -743,8 +759,8 @@ Item {
 
                 model: chooseCategories
 
-                // Bind currentIndex to the locale-invariant integer from the model.
-                currentIndex: !editCombos && model.ruleCategory >= 0 ? model.ruleCategory : currentIndex
+                // Bind to locale-invariant integer role from ProofModel.
+                currentIndex: model.ruleCategory >= 0 ? model.ruleCategory : currentIndex
             }
 
             // Second ComboBox to select rule
@@ -793,10 +809,8 @@ Item {
                     asteriskID.visible = false
                 }
 
-                // Bind currentIndex to the locale-invariant integer from the model.
-                // This binding survives language changes because it reads integers,
-                // not translated strings. When editCombos is true the user is editing.
-                currentIndex: !editCombos && model.ruleIndex >= 0 ? model.ruleIndex : currentIndex
+                // Bind to locale-invariant integer role from ProofModel.
+                currentIndex: model.ruleIndex >= 0 ? model.ruleIndex : currentIndex
 
                 model: combo2[chooseID.currentIndex]
             }

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -54,14 +54,14 @@ Item {
         proofModel.updateLines()
         proofModel.updateRefs(myIdx, false)
 
-        // After removal the boundary shifts to premiseCount - 1.
-        var insertAt = proofModel.premiseCount - 1
+        // After removal, recomputePremiseCount has already fired and premiseCount
+        // is now P-1. The insert boundary (first conclusion slot) is exactly premiseCount.
+        var insertAt = proofModel.premiseCount
         theData.insertLine(insertAt, insertAt + 1, pText, "choose",
                            pSub, pSubSt, pSubEnd, pInd, [-1])
         proofModel.updateLines()
         proofModel.updateRefs(insertAt, true)
         listView.currentIndex = insertAt
-        proofModel.premiseCount = proofModel.premiseCount - 1
 
         fileModified = true
         cConnector.evalText = "Evaluate Proof"
@@ -83,7 +83,6 @@ Item {
         proofModel.updateLines()
         proofModel.updateRefs(insertAt2, true)
         listView.currentIndex = insertAt2
-        proofModel.premiseCount = proofModel.premiseCount + 1
 
         fileModified = true
         cConnector.evalText = "Evaluate Proof"
@@ -196,7 +195,6 @@ Item {
                 proofModel.updateLines()
                 proofModel.updateRefs(insertIndex, true)
                 listView.currentIndex = insertIndex
-                proofModel.premiseCount = proofModel.premiseCount + 1
                 fileModified = true
                 cConnector.evalText = "Evaluate Proof"
                 proofModel.clearErrors()
@@ -233,8 +231,6 @@ Item {
                 var myType = proofModel.data(proofModel.index(myIdx, 0), 258)
 
                 if (listView.count > 1) {
-                    if (myType === "premise")
-                        proofModel.premiseCount = proofModel.premiseCount - 1
                     theData.removeLineAt(myIdx)
                     proofModel.updateLines()
                     proofModel.updateRefs(myIdx, false)
@@ -242,7 +238,6 @@ Item {
                 } else {
                     theData.removeLineAt(0)
                     theData.insertLine(0, 1, "", "premise", false, false, false, 0, [-1])
-                    proofModel.premiseCount = 1
                     proofModel.updateLines()
                     listView.currentIndex = 0
                 }
@@ -869,10 +864,6 @@ Item {
                 }
 
                 onClicked: {
-                    if (computePremise) {
-                        proofModel.recomputePremiseCount()
-                        computePremise = false
-                    }
                     optionsID.open()
                 }
 
@@ -904,7 +895,6 @@ Item {
                             listView.currentIndex = insertIndex
                             cConnector.evalText = "Evaluate Proof"
                             proofModel.clearErrors()
-                            proofModel.premiseCount = proofModel.premiseCount + 1
                         }
                     }
                     Action {
@@ -1000,9 +990,6 @@ Item {
                             proofModel.clearErrors()
 
                             if (listView.count > 1) {
-                                if (type === "premise")
-                                    proofModel.premiseCount = proofModel.premiseCount - 1
-
                                 var i = index
                                 theData.removeLineAt(index)
                                 proofModel.updateLines()
@@ -1010,7 +997,6 @@ Item {
                             } else {
                                 theData.removeLineAt(0)
                                 theData.insertLine(0, 1, "", "premise", false, false, false, 0, [-1])
-                                proofModel.premiseCount = 1
                                 proofModel.updateLines()
                                 listView.currentIndex = 0
                                 console.log("Goal 3: Last line reset to prevent blank screen crash.")

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -422,6 +422,11 @@ Item {
             property int indexx: model.index
             property bool vis: type === "premise" || type === "subproof"
                                || type === "sf"
+            // These delegate-level ints mirror the ProofModel roles.
+            // They must live here (not inside a ComboBox) because inside a ComboBox,
+            // `model` refers to the combo's own string-array model, NOT the row data.
+            property int savedRuleCategory: model.ruleCategory
+            property int savedRuleIndex:    model.ruleIndex
             property string textFieldColor: {
                 if (rootProofArea.selectedIndices.includes(indexx)) {
                     return darkMode ? "#5C469C" : "#E6E6FA"
@@ -444,10 +449,10 @@ Item {
             Connections {
                 target: settings
                 function onLanguageChanged() {
-                    if (model.ruleCategory >= 0)
-                        chooseID.currentIndex = model.ruleCategory
-                    if (model.ruleIndex >= 0)
-                        conclusionRuleID.currentIndex = model.ruleIndex
+                    if (outerColumn.savedRuleCategory >= 0)
+                        chooseID.currentIndex = outerColumn.savedRuleCategory
+                    if (outerColumn.savedRuleIndex >= 0)
+                        conclusionRuleID.currentIndex = outerColumn.savedRuleIndex
                 }
             }
 
@@ -759,8 +764,9 @@ Item {
 
                 model: chooseCategories
 
-                // Bind to locale-invariant integer role from ProofModel.
-                currentIndex: model.ruleCategory >= 0 ? model.ruleCategory : currentIndex
+                // Use delegate-level savedRuleCategory (not `model.ruleCategory` here,
+                // because inside a ComboBox `model` shadows the row data).
+                currentIndex: outerColumn.savedRuleCategory >= 0 ? outerColumn.savedRuleCategory : currentIndex
             }
 
             // Second ComboBox to select rule
@@ -809,10 +815,26 @@ Item {
                     asteriskID.visible = false
                 }
 
-                // Bind to locale-invariant integer role from ProofModel.
-                currentIndex: model.ruleIndex >= 0 ? model.ruleIndex : currentIndex
-
+                // DO NOT use a declarative `currentIndex:` binding here.
+                // When chooseID.currentIndex changes, combo2[cat] changes,
+                // which causes QML to reset currentIndex internally — destroying
+                // any declarative binding. Instead we use onModelChanged to
+                // re-apply the saved ruleIndex after the model swap settles.
                 model: combo2[chooseID.currentIndex]
+
+                Component.onCompleted: {
+                    // `model` here is the combo's string array — use outerColumn.savedRuleIndex.
+                    if (outerColumn.savedRuleIndex >= 0)
+                        currentIndex = outerColumn.savedRuleIndex
+                }
+
+                onModelChanged: {
+                    // Fires when chooseID.currentIndex changes (during load or user action).
+                    if (!editCombos && outerColumn.savedRuleIndex >= 0)
+                        currentIndex = outerColumn.savedRuleIndex   // restore on load
+                    else if (editCombos)
+                        currentIndex = 0   // user picked a new category → start at rule 0
+                }
             }
 
             // Display Asterisk next to ComboBox if rule not chosen

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -89,13 +89,35 @@ Item {
         proofModel.clearErrors()
     }
 
-    property var combo2: [
-        [qsTr("Modus Ponens"), qsTr("Addition"), qsTr("Simplification"), qsTr("Conjunction"), qsTr("Hypothetical Syllogism"), qsTr("Disjunctive Syllogism"), qsTr("Excluded middle"), qsTr("Constructive Dilemma"), qsTr("XOR Introduction"), qsTr("XOR Elimination")],
-        [qsTr("Implication"), qsTr("DeMorgan"), qsTr("Association"), qsTr("Commutativity"), qsTr("Idempotence"), qsTr("Distribution"), qsTr("Equivalence"), qsTr("Double Negation"), qsTr("Exportation"), qsTr("Subsumption"), qsTr("Contrapositive")],
-        [qsTr("Universal Generalization"), qsTr("Universal Instantiation"), qsTr("Existential Generalization"), qsTr("Existential Instantiation"), qsTr("Bound Variable Substitution"), qsTr("Null Quantifier"), qsTr("Prenex"), qsTr("Identity"), qsTr("Free Variable Substitution")],
-        [qsTr("Lemma"), qsTr("Subproof"), qsTr("Sequence"), qsTr("Induction")],
-        [qsTr("Identity "), qsTr("Negation"), qsTr("Dominance"), qsTr("Symbol Negation")]
-    ]
+    property var chooseCategories: getChooseCategories()
+    property var combo2: getCombo2()
+
+    function getChooseCategories() {
+        return [qsTr("Inference"), qsTr("Equivalence"), qsTr("Predicate"), qsTr("Miscellaneous"), qsTr("Boolean")]
+    }
+
+    function getCombo2() {
+        return [
+            [qsTr("Modus Ponens"), qsTr("Addition"), qsTr("Simplification"), qsTr("Conjunction"), qsTr("Hypothetical Syllogism"), qsTr("Disjunctive Syllogism"), qsTr("Excluded middle"), qsTr("Constructive Dilemma"), qsTr("XOR Introduction"), qsTr("XOR Elimination")],
+            [qsTr("Implication"), qsTr("DeMorgan"), qsTr("Association"), qsTr("Commutativity"), qsTr("Idempotence"), qsTr("Distribution"), qsTr("Equivalence"), qsTr("Double Negation"), qsTr("Exportation"), qsTr("Subsumption"), qsTr("Contrapositive")],
+            [qsTr("Universal Generalization"), qsTr("Universal Instantiation"), qsTr("Existential Generalization"), qsTr("Existential Instantiation"), qsTr("Bound Variable Substitution"), qsTr("Null Quantifier"), qsTr("Prenex"), qsTr("Identity"), qsTr("Free Variable Substitution")],
+            [qsTr("Lemma"), qsTr("Subproof"), qsTr("Sequence"), qsTr("Induction")],
+            [qsTr("Identity "), qsTr("Negation"), qsTr("Dominance"), qsTr("Symbol Negation")]
+        ]
+    }
+
+    function refreshTranslations() {
+        chooseCategories = getChooseCategories()
+        combo2 = getCombo2()
+    }
+
+    Connections {
+        target: settings
+        function onLanguageChanged() {
+            refreshTranslations()
+        }
+    }
+
     anchors.fill: parent
 
     Shortcut {
@@ -477,6 +499,7 @@ Item {
                                 proofModel.setData(proofModel.index(
                                                        listView.currentIndex,
                                                        0), array, 263)
+                                fileModified = true
                                 refreshTextFieldColor()
                                 return
                             }
@@ -485,6 +508,7 @@ Item {
                         proofModel.setData(proofModel.index(
                                                listView.currentIndex, 0),
                                            array, 263)
+                        fileModified = true
                         refreshTextFieldColor()
                     }
                 }
@@ -631,6 +655,8 @@ Item {
                     }
                 }
 
+                onTextEdited: fileModified = true
+
                 // Save Text inside Model
                 onEditingFinished: {
                     if (model.lText !== text) {
@@ -711,10 +737,11 @@ Item {
                     editCombos = true
                     proofModel.setData(proofModel.index(indexx, 0),
                                        currentIndex, 265)  // RuleCategoryRole
+                    fileModified = true
                     asteriskID.visible = false
                 }
 
-                model: [qsTr("Inference"), qsTr("Equivalence"), qsTr("Predicate"), qsTr("Miscellaneous"), qsTr("Boolean")]
+                model: chooseCategories
 
                 // Bind currentIndex to the locale-invariant integer from the model.
                 currentIndex: !editCombos && model.ruleCategory >= 0 ? model.ruleCategory : currentIndex
@@ -762,6 +789,7 @@ Item {
                     // Write the rule index integer (locale-invariant).
                     proofModel.setData(proofModel.index(indexx, 0),
                                        currentIndex, 266)  // RuleIndexRole
+                    fileModified = true
                     asteriskID.visible = false
                 }
 
@@ -826,6 +854,7 @@ Item {
                             proofModel.setData(proofModel.index(
                                                    listView.currentIndex,
                                                    0), ar, 263)
+                            fileModified = true
                             cConnector.evalText = "Evaluate Proof"
                             proofModel.clearErrors()
                         }

--- a/qt/auxconnector.cpp
+++ b/qt/auxconnector.cpp
@@ -212,8 +212,11 @@ void auxConnector::importProof(const QString &name, ProofData *pd, const Connect
 
             if (sd->depth > 0)
                 sd->rule = -2;
-            pd->insertLine(num_ins,num_ins+1,(const char *) sd->text,c->reverseRulesMap[sd->rule],false,
-                               false,false, sd->depth * 20,temp_refs);
+            {
+                auto ci = Connector::getCategoryAndIndex(sd->rule);
+                pd->insertLine(num_ins,num_ins+1,(const char *) sd->text,c->reverseRulesMap[sd->rule],false,
+                                   false,false, sd->depth * 20,temp_refs, ci.first, ci.second);
+            }
             pd->setFile(num_ins,newName);
             pm->updateLines();
             pm->updateRefs(num_ins,true);
@@ -272,8 +275,11 @@ void auxConnector::importProof(const QString &name, ProofData *pd, const Connect
             for (int i = 0; sd->refs[i] != REF_END; i++)
                 temp_refs.push_back(sd->refs[i]);
 
-            pd->insertLine(l,l+1,(const char *) sd->text,c->reverseRulesMap[sd->rule],false,
-                           false,false, sd->depth * 20,temp_refs);
+            {
+                auto ci = Connector::getCategoryAndIndex(sd->rule);
+                pd->insertLine(l,l+1,(const char *) sd->text,c->reverseRulesMap[sd->rule],false,
+                               false,false, sd->depth * 20,temp_refs, ci.first, ci.second);
+            }
             pd->setFile(l,newName);
             pm->updateLines();
             pm->updateRefs(l,true);
@@ -344,7 +350,8 @@ void auxConnector::importProofWithMode(const QString &name, ProofData *pd, const
         const QList<int> refs = shiftedRefs(line.pRefs, refDelta);
 
         pd->insertLine(targetIndex, targetIndex + 1, line.pText, line.pType,
-                       line.pSub, line.pSubStart, line.pSubEnd, line.pInd, refs);
+                       line.pSub, line.pSubStart, line.pSubEnd, line.pInd, refs,
+                       line.pRuleCategory, line.pRuleIndex);
 
         if (line.fname)
             pd->setFile(targetIndex, QString::fromUtf8((const char *) line.fname));

--- a/qt/auxconnector.cpp
+++ b/qt/auxconnector.cpp
@@ -110,8 +110,10 @@ void auxConnector::latex(const QString &name, const ProofData *toBeEval, Connect
     if (convert_proof_latex(c->getCProof(),file_name) == 0){
         qDebug() << "Latex conversion successful";
     }
-    else
+    else {
         qDebug() << "Memory Error";
+        emit errorOccurred(tr("LaTeX export failed: could not convert proof to LaTeX format."));
+    }
     if (file_name)
         free(file_name);
 
@@ -153,6 +155,7 @@ void auxConnector::importProof(const QString &name, ProofData *pd, const Connect
 
     if (!proof) {
         qDebug() << "Failed to import proof";
+        emit errorOccurred(tr("Import failed: the selected file could not be opened or is not a valid Aris proof."));
         free(file_name);
         emit importFinished(false);
         return;

--- a/qt/auxconnector.h
+++ b/qt/auxconnector.h
@@ -41,6 +41,7 @@ public:
 
 signals:
     void importFinished(bool success);
+    void errorOccurred(const QString &message);
 
 private:
 

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -154,6 +154,12 @@ void Connector::setAutoSaveStatus(const QString &status)
     emit autoSaveStatusChanged();
 }
 
+// Getter for m_lastError
+QString Connector::lastError() const
+{
+    return m_lastError;
+}
+
 /* Returns true once the IDBFS FS.syncfs(true) startup callback has fired.
   * Reads a JS flag set by main.cpp's EM_ASM block.
   * Uses EM_ASM_INT which is compiled at build time — NOT runtime eval
@@ -420,10 +426,13 @@ void Connector::saveProof(const QString &name, const ProofData *toBeSaved, const
     char *file_name = (char *) calloc((nameStr.size()+1), sizeof(char));
     memcpy(file_name, nameStr.c_str(), nameStr.size());
 
-    if (aio_save(cProof,(const char *) file_name) == 0)
+    if (aio_save(cProof,(const char *) file_name) == 0) {
         qDebug() << "File Saved Successfully";
-    else
-        qDebug() << "File Save Failed for path:" << localName;
+    } else {
+        m_lastError = tr("File save failed for path: %1").arg(localName);
+        qDebug() << m_lastError;
+        emit errorOccurred(m_lastError);
+    }
     if (file_name)
         free(file_name);
 }
@@ -450,10 +459,13 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
 
     releaseCProof(cProof);
     cProof = aio_open((const char *) file_name);
-    if (cProof)
+    if (cProof) {
         qDebug() << "File Opened Successfully";
-    else
-        qDebug() << "File Open Failed for path:" << localName;
+    } else {
+        m_lastError = tr("File open failed for path: %1").arg(localName);
+        qDebug() << m_lastError;
+        emit errorOccurred(m_lastError);
+    }
     if (file_name)
         free(file_name);
 

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -915,8 +915,15 @@ void Connector::autoLoad(ProofData *openTo, GoalData *gls)
 
     qDebug() << "[ARIS] autoLoad: Autosave found — restoring proof from IndexedDB...";
 
-    // Reuse the existing openProof() which calls aio_open() internally.
+    blockSignals(true);
     openProof("/persistent/autosave.tle", openTo, gls);
+    blockSignals(false);
+
+    if (!cProof) {
+
+        qDebug() << "[ARIS] autoLoad: Autosave could not be parsed — starting with a blank proof.";
+        return;
+    }
 
     qDebug() << "[ARIS] autoLoad: Proof restored successfully.";
 #else

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -910,6 +910,7 @@ void Connector::autoLoad(ProofData *openTo, GoalData *gls)
     QFile autosaveCheck("/persistent/autosave.tle");
     if (!autosaveCheck.exists()) {
         qDebug() << "[ARIS] autoLoad: No autosave found — starting with a blank proof.";
+        emit autoLoadDone(false);
         return;
     }
 
@@ -922,10 +923,12 @@ void Connector::autoLoad(ProofData *openTo, GoalData *gls)
     if (!cProof) {
 
         qDebug() << "[ARIS] autoLoad: Autosave could not be parsed — starting with a blank proof.";
+        emit autoLoadDone(false);
         return;
     }
 
     qDebug() << "[ARIS] autoLoad: Proof restored successfully.";
+    emit autoLoadDone(true);
 #else
     Q_UNUSED(openTo)
     Q_UNUSED(gls)

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -264,7 +264,14 @@ void Connector::genProof(const ProofData *toBeEval)
 
 
         constexpr int RULE_UNKNOWN = -99;
-        int rule     = rulesMap.value(pl.pType, RULE_UNKNOWN);
+        int rule;
+        
+        if (pl.pRuleCategory >= 0 && pl.pRuleIndex >= 0) {
+            static const int offsets[] = {0, 10, 21, 30, 34};
+            rule = offsets[pl.pRuleCategory] + pl.pRuleIndex;
+        } else {
+            rule = rulesMap.value(pl.pType, RULE_UNKNOWN);
+        }
         int depth    = pl.pInd / 20;
         int premise  = (rule == -1 || pl.pType.isEmpty()) ? 1 : 0;
         int subproof = (rule == -2) ? 1 : 0;
@@ -494,8 +501,15 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
 
         if (sd->depth > d)
             sd->rule = -2;
-        openTo->insertLine(sd->line_num-1,sd->line_num,(const char *) sd->text,reverseRulesMap[sd->rule],(sd->depth > 0),
-                           (sd->rule == -2),(sd->line_num != 1 && ((sen_data *) pf_itr->prev->value)->depth > sd->depth), sd->depth * 20,temp_refs);
+        {
+            auto ci = getCategoryAndIndex(sd->rule);
+            openTo->insertLine(sd->line_num-1,sd->line_num,(const char *) sd->text,
+                               reverseRulesMap[sd->rule],(sd->depth > 0),
+                               (sd->rule == -2),
+                               (sd->line_num != 1 && ((sen_data *) pf_itr->prev->value)->depth > sd->depth),
+                               sd->depth * 20, temp_refs,
+                               ci.first, ci.second);
+        }
         d = sd->depth;
     }
 
@@ -774,7 +788,14 @@ void Connector::smartPaste(ProofData *pd, ProofModel *pm)
 
         //  Pass line (QString) directly — insertLine already takes QString.
         // The old toStdString().c_str() was UB: pointer into a temporary std::string.
-        pd->insertLine(insertIdx, insertIdx + 1, line, foundRule, false, false, false, 0, refs);
+        {
+            // Derive (cat, idx) from the rule string so the model integers are
+            // populated immediately on paste, not lazily by the combo binding.
+            int ruleId = rulesMap.value(foundRule, -1);
+            auto ci = getCategoryAndIndex(ruleId);
+            pd->insertLine(insertIdx, insertIdx + 1, line, foundRule, false, false, false, 0, refs,
+                           ci.first, ci.second);
+        }
         insertIdx++;
     }
 

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -118,7 +118,7 @@ void Connector::reverseMapInit()
     reverseRulesMap[21] = "Universal Generalization";       reverseRulesMap[22] = "Universal Instantiation";
     reverseRulesMap[23] = "Existential Generalization";     reverseRulesMap[24] = "Existential Instantiation";      reverseRulesMap[25] = "Bound Variable Substitution";
     reverseRulesMap[26] = "Null Quantifier";                reverseRulesMap[27] = "Prenex";                         reverseRulesMap[28] = "Identity";
-    reverseRulesMap[29] = "Free Variable Substitution";     reverseRulesMap[30] = "Lemma";                          reverseRulesMap[31] = "subproof";
+    reverseRulesMap[29] = "Free Variable Substitution";     reverseRulesMap[30] = "Lemma";                          reverseRulesMap[31] = "Subproof";
     reverseRulesMap[32] = "Sequence";                       reverseRulesMap[33] = "Induction";                      reverseRulesMap[34] = "Boolean Identity";
     reverseRulesMap[35] = "Boolean Negation";               reverseRulesMap[36] = "Boolean Dominance";              reverseRulesMap[37] = "Symbol Negation";
     reverseRulesMap[-2] = "sf";
@@ -244,7 +244,7 @@ void Connector::genProof(const ProofData *toBeEval)
 {
     m_conns = gui_conns;
     int conn = 1;
-    std::regex pat("[&|~$%@#!^:>]");
+    std::regex pat("[&|~$%@#!?^:>]");
  
     releaseCProof(cProof);
     cProof = proof_init();
@@ -499,17 +499,17 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
         for (int i = 0; sd->refs[i] != REF_END; i++)
             temp_refs.push_back(sd->refs[i]);
 
+        int effectiveRule = sd->rule;
         if (sd->depth > d)
-            sd->rule = -2;
-        {
-            auto ci = getCategoryAndIndex(sd->rule);
-            openTo->insertLine(sd->line_num-1,sd->line_num,(const char *) sd->text,
-                               reverseRulesMap[sd->rule],(sd->depth > 0),
-                               (sd->rule == -2),
-                               (sd->line_num != 1 && ((sen_data *) pf_itr->prev->value)->depth > sd->depth),
-                               sd->depth * 20, temp_refs,
-                               ci.first, ci.second);
-        }
+            effectiveRule = -2;  // subproof start — don't mutate sd->rule itself
+
+        auto ci = getCategoryAndIndex(effectiveRule);
+        openTo->insertLine(sd->line_num-1, sd->line_num, (const char *) sd->text,
+                           reverseRulesMap[effectiveRule], (sd->depth > 0),
+                           (effectiveRule == -2),
+                           (sd->line_num != 1 && ((sen_data *) pf_itr->prev->value)->depth > sd->depth),
+                           sd->depth * 20, temp_refs,
+                           ci.first, ci.second);
         d = sd->depth;
     }
 

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -236,7 +236,7 @@ void Connector::genIndices(const ProofData *toBeEval)
  */
 void Connector::genProof(const ProofData *toBeEval)
 {
-    main_conns = gui_conns;
+    m_conns = gui_conns;
     int conn = 1;
     std::regex pat("[&|~$%@#!^:>]");
  
@@ -278,7 +278,7 @@ void Connector::genProof(const ProofData *toBeEval)
         std::string str = pl.pText.toStdString();
 
         if (conn && std::regex_search(str, pat)) {
-            main_conns = cli_conns;
+            m_conns = cli_conns;
             conn = 0;
         }
 
@@ -354,7 +354,7 @@ int Connector::evalProof(const ProofData *toBeEval, const GoalData *gls, ProofMo
         destroy_str_vec(returns);
     returns = init_vec(sizeof(char *));
 
-    if (!proof_eval(cProof, returns, 1))
+    if (!proof_eval(cProof, returns, 1, m_conns))
         qDebug() << "Proof Evaluated Successfully";
     else
         qDebug() << "Memory Error";

--- a/qt/connector.h
+++ b/qt/connector.h
@@ -22,6 +22,7 @@
 #include <QObject>
 #include <QHash>
 #include "../src/typedef.h"
+#include "../src/process.h"
 #include "proofdata.h"
 #include "goaldata.h"
 #include "proofmodel.h"
@@ -81,6 +82,7 @@ signals:
 private:
     proof_t * cProof;
     vec_t * returns;
+    struct connectives_list m_conns;   // connectives chosen by genProof()
 //    QHash<QString,int> rulesMap;
 //    QHash<int,QString> reverseRulesMap;
     QString m_evalText;

--- a/qt/connector.h
+++ b/qt/connector.h
@@ -74,6 +74,17 @@ public:
     QHash<QString,int> rulesMap;
     QHash<int,QString> reverseRulesMap;
 
+    // Converts a C engine rule ID back to (category, index) pair used by the
+    // UI combo boxes.  Returns {-1,-1} for structural tokens (-1, -2, etc.).
+    static QPair<int,int> getCategoryAndIndex(int engineRuleId) {
+        if (engineRuleId >= 0  && engineRuleId <= 9)  return {0, engineRuleId};
+        if (engineRuleId >= 10 && engineRuleId <= 20) return {1, engineRuleId - 10};
+        if (engineRuleId >= 21 && engineRuleId <= 29) return {2, engineRuleId - 21};
+        if (engineRuleId >= 30 && engineRuleId <= 33) return {3, engineRuleId - 30};
+        if (engineRuleId >= 34 && engineRuleId <= 37) return {4, engineRuleId - 34};
+        return {-1, -1};
+    }
+
 signals:
 
     void evalTextChanged();

--- a/qt/connector.h
+++ b/qt/connector.h
@@ -92,6 +92,7 @@ signals:
     void errorOccurred(const QString &message);
     void smartPasteStarted();
     void smartPasteDone();
+    void autoLoadDone(bool success);
 
 
 private:

--- a/qt/connector.h
+++ b/qt/connector.h
@@ -37,12 +37,15 @@ public:
 
     Q_PROPERTY(QString evalText READ evalText WRITE setEvalText NOTIFY evalTextChanged)
     Q_PROPERTY(QString autoSaveStatus READ autoSaveStatus NOTIFY autoSaveStatusChanged)
+    Q_PROPERTY(QString lastError READ lastError NOTIFY errorOccurred)
 
     QString evalText() const;
     void setEvalText(const QString &newEvalText);
 
     QString autoSaveStatus() const;
     void setAutoSaveStatus(const QString &status);
+
+    QString lastError() const;
 
     void genIndices(const ProofData * toBeEval);
     void genProof(const ProofData * toBeEval);
@@ -75,6 +78,7 @@ signals:
 
     void evalTextChanged();
     void autoSaveStatusChanged();
+    void errorOccurred(const QString &message);
     void smartPasteStarted();
     void smartPasteDone();
 
@@ -87,6 +91,7 @@ private:
 //    QHash<int,QString> reverseRulesMap;
     QString m_evalText;
     QString m_autoSaveStatus;
+    QString m_lastError;
     QList<QList<int>> m_indices;
 };
 

--- a/qt/goalmodel.cpp
+++ b/qt/goalmodel.cpp
@@ -157,7 +157,11 @@ void GoalModel::evalGoals(GoalData *gls, Connector *c)
             setData(index(i,0),ln,256);
             setData(index(i,0),(is_valid == 1),258);
         }
-        else
+        else {
             qDebug() << "Error in checking goal " << i + 1 << ":\n\t Goal was probably empty or invalid";
+            c->setEvalText(QStringLiteral("⚠ ") +
+                           c->tr("Goal %1 could not be evaluated — it may be malformed or contain invalid syntax.")
+                               .arg(i + 1));
+        }
     }
 }

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -33,7 +33,6 @@ ApplicationWindow {
     property string filename: "Untitled"
     property bool fileExists: isExtFile
     property bool fileModified: false
-    property bool computePremise: false // set to true if Open or Import Proof are used
     property int importMode: 0
 
     //  Zoom infrastructure (Proof Line section only) 
@@ -51,8 +50,8 @@ ApplicationWindow {
     function zoomReset() { zoomFactor = 1.0 }
    
 
-    // premiseCount is now a C++ Q_PROPERTY on proofModel.
-    // Use proofModel.recomputePremiseCount() after opening/importing a file.
+    // premiseCount is a read-only C++ Q_PROPERTY on proofModel.
+    // It is automatically recomputed whenever lines are inserted or removed.
 
     // Function to check if the item is a TextField QML Type
     function isTextField(item) {
@@ -65,8 +64,6 @@ ApplicationWindow {
 
         theGoals.reset()
 
-        proofModel.premiseCount = 1
-        computePremise = false
         isExtFile = false
         fileExists = false
         fileModified = false
@@ -98,8 +95,6 @@ ApplicationWindow {
         cConnector.evalText = "Evaluate Proof"
         proofModel.clearErrors()
         isExtFile = true
-        computePremise = true
-
         importBehaviorID.close()
         menuOptions.close()
 
@@ -270,7 +265,6 @@ ApplicationWindow {
             // Called at the very start of smartPaste() — mark proof as
             // coming from an external source so the UI renders ref numbers.
             isExtFile = true
-            computePremise = true
             cConnector.evalText = "Evaluate Proof"
             proofModel.clearErrors()
         }
@@ -365,8 +359,6 @@ ApplicationWindow {
             filename = selectedFile
             isExtFile = true
             fileModified = false
-            computePremise = true
-            proofModel.recomputePremiseCount()
             // Immediately autosave the newly opened file so the autosave
             if (Qt.platform.os === "wasm")
                 cConnector.autoSave(theData, theGoals)
@@ -411,7 +403,6 @@ ApplicationWindow {
         onAccepted: {
             auxConnector.importProofWithMode(selectedFile, theData, cConnector,
                                      proofModel, importMode)
-            proofModel.recomputePremiseCount()
         }
     }
 
@@ -673,7 +664,7 @@ ApplicationWindow {
     Shortcut {
         sequences: [StandardKey.Paste]
         onActivated: {
-            // smartPasteStarted signal sets isExtFile/computePremise before rows are inserted
+            // smartPasteStarted signal sets isExtFile before rows are inserted
             cConnector.smartPaste(theData, proofModel)
         }
     }

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -255,7 +255,15 @@ ApplicationWindow {
                 // autosave reflects what was imported, not the previous state.
                 if (Qt.platform.os === "wasm")
                     cConnector.autoSave(theData, theGoals)
+            } else {
+                // No-op: Error already set by errorOccurred, or user cancelled dialog.
             }
+        }
+
+        function onErrorOccurred(message) {
+            // Route auxConnector errors (LaTeX export, import parse) to the
+            // same footer status bar used by cConnector errors.
+            cConnector.evalText = "⚠ " + message
         }
     }
 

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -275,6 +275,11 @@ ApplicationWindow {
             fileModified = true
             menuOptions.close()
         }
+
+        function onErrorOccurred(message) {
+            // Route file I/O errors to the footer status bar (already red).
+            cConnector.evalText = "⚠ " + message
+        }
     }
 
     

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -249,6 +249,7 @@ ApplicationWindow {
 
         function onImportFinished(success) {
             if (success) {
+                isExtFile = true
                 fileModified = true
                 // Immediately autosave the newly imported content so the
                 // autosave reflects what was imported, not the previous state.
@@ -260,6 +261,12 @@ ApplicationWindow {
 
     Connections {
         target: cConnector
+
+        function onAutoLoadDone(success) {
+            if (success) {
+                isExtFile = true
+            }
+        }
 
         function onSmartPasteStarted() {
             // Called at the very start of smartPaste() — mark proof as

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -21,6 +21,7 @@ import QtQuick.Window 2.15
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.5
 import QtQuick.Dialogs
+import Qt.labs.settings 1.0
 import proof.model 1.0
 import goal.model 1.0
 
@@ -29,17 +30,30 @@ ApplicationWindow {
 
     property font thefont: rootID.font
     property bool isExtFile: false // If the file is opened from an external file
-    property bool darkMode: false
+    property bool darkMode: appPrefs.darkMode
     property string filename: "Untitled"
     property bool fileExists: isExtFile
     property bool fileModified: false
     property int importMode: 0
 
-    //  Zoom infrastructure (Proof Line section only) 
-    property real zoomFactor: 1.0          // single source of truth
+    //  Zoom infrastructure (Proof Line section only)
+    property real zoomFactor: appPrefs.zoomFactor
     readonly property real zoomMin:  0.3
     readonly property real zoomMax:  2.0
     readonly property real zoomStep: 0.1
+
+    // Persist user preferences across reloads (localStorage on WASM, QSettings on desktop).
+    Settings {
+        id: appPrefs
+        category: "ArisPreferences"
+        property string language: "en"
+        property bool   darkMode: false
+        property real   zoomFactor: 1.0
+    }
+
+    // Keep persisted prefs in sync whenever the user changes them at runtime.
+    onDarkModeChanged:  appPrefs.darkMode   = darkMode
+    onZoomFactorChanged: appPrefs.zoomFactor = zoomFactor
 
     // Convenience helpers consumed by ProofArea.qml
     readonly property real scaledFontSize: Math.round(thefont.pointSize * zoomFactor)
@@ -185,6 +199,9 @@ ApplicationWindow {
 
     Component.onCompleted: () => {
         qsTr("QT_LAYOUT_DIRECTION", "QGuiApplication");
+        // Restore language preference saved from the previous session.
+        if (appPrefs.language !== "en")
+            settings.setLanguage(appPrefs.language)
     }
 
     onClosing: function(close) {

--- a/qt/proofdata.cpp
+++ b/qt/proofdata.cpp
@@ -39,7 +39,9 @@ bool ProofData::setLineAt(int index, const ProofLine &proofLine)
         && oldLine.pSub == proofLine.pSub && oldLine.pSubEnd == proofLine.pSubEnd \
         && oldLine.pSubStart == proofLine.pSubStart && oldLine.pInd == proofLine.pInd \
         && oldLine.pType == proofLine.pType && oldLine.pRefs == proofLine.pRefs \
-        && oldLine.pErrorMsg == proofLine.pErrorMsg)
+        && oldLine.pErrorMsg == proofLine.pErrorMsg \
+        && oldLine.pRuleCategory == proofLine.pRuleCategory \
+        && oldLine.pRuleIndex == proofLine.pRuleIndex)
     {
         return false;
     }
@@ -56,7 +58,7 @@ void ProofData::setFile(int index, const QString &name)
 }
 
 // Insert a proof line (in m_proofLines) at a valid index
-void ProofData::insertLine(int index,int a, QString b, QString c, bool d, bool e, bool f, int g, QList<int> h)
+void ProofData::insertLine(int index,int a, QString b, QString c, bool d, bool e, bool f, int g, QList<int> h, int cat, int idx)
 {
     emit preLineInsert(index);
 
@@ -71,6 +73,8 @@ void ProofData::insertLine(int index,int a, QString b, QString c, bool d, bool e
     aLine.pRefs = h;
     aLine.fname = NULL;
     aLine.pErrorMsg = QString();  // always start with no error
+    aLine.pRuleCategory = cat;
+    aLine.pRuleIndex = idx;
     m_proofLines.insert(index,aLine);
 
     emit postLineInsert();

--- a/qt/proofdata.h
+++ b/qt/proofdata.h
@@ -31,6 +31,13 @@ struct ProofLine{
     QList<int> pRefs;
     unsigned char *fname;
     QString pErrorMsg;   // inline error text, empty = no error
+
+    // Locale-invariant combo-box position.  -1 means structural / not a rule.
+    // pRuleCategory: index into the outer combo (0=Inference, 1=Equivalence,
+    //                2=Predicate, 3=Miscellaneous, 4=Boolean).
+    // pRuleIndex   : index within combo2[pRuleCategory].
+    int pRuleCategory = -1;
+    int pRuleIndex    = -1;
 };
 
 class ProofData : public QObject
@@ -52,7 +59,7 @@ signals:
     void postLineRemove();
 
 public slots:
-    void insertLine(int index, int a, QString b, QString c, bool d, bool e, bool f, int g, QList<int> h);
+    void insertLine(int index, int a, QString b, QString c, bool d, bool e, bool f, int g, QList<int> h, int cat = -1, int idx = -1);
     void removeLineAt(int index);
     void setErrorAt(int index, const QString &msg);   // set inline error for a line
     Q_INVOKABLE void reset();

--- a/qt/proofmodel.cpp
+++ b/qt/proofmodel.cpp
@@ -192,7 +192,11 @@ bool ProofModel::setData(const QModelIndex &index, const QVariant &value, int ro
     }
 
     if (mLines->setLineAt(index.row(),someLine)) {
-        emit dataChanged(index, index, {role});
+        if (role == TypeRole || role == RuleCategoryRole || role == RuleIndexRole) {
+            emit dataChanged(index, index, {TypeRole, RuleCategoryRole, RuleIndexRole});
+        } else {
+            emit dataChanged(index, index, {role});
+        }
         return true;
     }
     return false;

--- a/qt/proofmodel.cpp
+++ b/qt/proofmodel.cpp
@@ -17,6 +17,52 @@
 */
 #include "proofmodel.h"
 
+// Static helpers — locale-invariant rule name ↔ (category, index) mapping
+
+
+// canonical rule names ordered exactly as the combo2 arrays in ProofArea.qml
+static const char * const kRuleNames[][11] = {
+    // cat 0 — Inference (10 rules)
+    {"Modus Ponens","Addition","Simplification","Conjunction",
+     "Hypothetical Syllogism","Disjunctive Syllogism","Excluded middle",
+     "Constructive Dilemma","XOR Introduction","XOR Elimination", nullptr},
+    // cat 1 — Equivalence (11 rules)
+    {"Implication","DeMorgan","Association","Commutativity","Idempotence",
+     "Distribution","Equivalence","Double Negation","Exportation",
+     "Subsumption","Contrapositive"},
+    // cat 2 — Predicate (9 rules)
+    {"Universal Generalization","Universal Instantiation",
+     "Existential Generalization","Existential Instantiation",
+     "Bound Variable Substitution","Null Quantifier","Prenex",
+     "Identity","Free Variable Substitution"},
+    // cat 3 — Miscellaneous (4 rules)
+    {"Lemma","Subproof","Sequence","Induction"},
+    // cat 4 — Boolean (4 rules)
+    {"Boolean Identity","Boolean Negation","Boolean Dominance","Symbol Negation"}
+};
+static const int kRuleCounts[] = {10, 11, 9, 4, 4};
+
+/*static*/ const QHash<QString, ProofModel::RulePos> &ProofModel::rulePosMap()
+{
+    static QHash<QString, RulePos> m;
+    if (m.isEmpty()) {
+        for (int cat = 0; cat < 5; ++cat) {
+            for (int idx = 0; idx < kRuleCounts[cat]; ++idx) {
+                m.insert(QString::fromLatin1(kRuleNames[cat][idx]), RulePos{cat, idx});
+            }
+        }
+    }
+    return m;
+}
+
+/*static*/ QString ProofModel::canonicalName(int cat, int idx)
+{
+    if (cat < 0 || cat > 4) return QString();
+    if (idx < 0 || idx >= kRuleCounts[cat]) return QString();
+    return QString::fromLatin1(kRuleNames[cat][idx]);
+}
+
+
 ProofModel::ProofModel(QObject *parent)
     : QAbstractListModel(parent), mLines(nullptr)
 {
@@ -64,6 +110,10 @@ QVariant ProofModel::data(const QModelIndex &index, int role) const
     }
     case ErrorRole:
         return QVariant(someLine.pErrorMsg);
+    case RuleCategoryRole:
+        return QVariant(someLine.pRuleCategory);
+    case RuleIndexRole:
+        return QVariant(someLine.pRuleIndex);
     }
     return QVariant();
 }
@@ -83,9 +133,21 @@ bool ProofModel::setData(const QModelIndex &index, const QVariant &value, int ro
     case TextRole:
         someLine.pText = value.toString();
         break;
-    case TypeRole:
+    case TypeRole: {
         someLine.pType = value.toString();
+        // Derive the integer combo position from the canonical English name so
+        // QML combo boxes always have a locale-invariant index to bind to.
+        auto it = rulePosMap().constFind(someLine.pType);
+        if (it != rulePosMap().constEnd()) {
+            someLine.pRuleCategory = it->cat;
+            someLine.pRuleIndex    = it->idx;
+        } else {
+            // Structural token ("premise", "sf", "subproof", "choose") or unknown.
+            someLine.pRuleCategory = -1;
+            someLine.pRuleIndex    = -1;
+        }
         break;
+    }
     case SubRole:
         someLine.pSub = value.toBool();
         break;
@@ -111,6 +173,22 @@ bool ProofModel::setData(const QModelIndex &index, const QVariant &value, int ro
         mLines->setErrorAt(index.row(), value.toString());
         emit dataChanged(index, index, {role});
         return true;
+    case RuleCategoryRole:
+        someLine.pRuleCategory = value.toInt();
+        someLine.pRuleIndex = mLines->lines().at(index.row()).pRuleIndex;
+        {
+            const QString name = canonicalName(someLine.pRuleCategory, someLine.pRuleIndex);
+            if (!name.isEmpty()) someLine.pType = name;
+        }
+        break;
+    case RuleIndexRole:
+        someLine.pRuleIndex = value.toInt();
+        someLine.pRuleCategory = mLines->lines().at(index.row()).pRuleCategory;
+        {
+            const QString name = canonicalName(someLine.pRuleCategory, someLine.pRuleIndex);
+            if (!name.isEmpty()) someLine.pType = name;
+        }
+        break;
     }
 
     if (mLines->setLineAt(index.row(),someLine)) {
@@ -141,6 +219,8 @@ QHash<int, QByteArray> ProofModel::roleNames() const
     names[IndentRole] = "ind";
     names[RefsRole] = "refs";
     names[ErrorRole] = "errMsg";
+    names[RuleCategoryRole] = "ruleCategory";
+    names[RuleIndexRole]    = "ruleIndex";
     return names;
 }
 
@@ -261,15 +341,20 @@ bool ProofModel::toggleLineType(int row)
     if (ln.pType == "premise") {
         ln.pType = "choose";
         ln.pRefs = {-1};
+        // Entering "choose" state: clear rule integers so the UI starts fresh.
+        ln.pRuleCategory = -1;
+        ln.pRuleIndex    = -1;
         if (!mLines->setLineAt(row, ln)) return false;
-        emit dataChanged(index(row, 0), index(row, 0), {TypeRole, RefsRole});
+        emit dataChanged(index(row, 0), index(row, 0), {TypeRole, RefsRole, RuleCategoryRole, RuleIndexRole});
         recomputePremiseCount();
     } else {
         // Any non-premise, non-subproof type → "premise"
         ln.pType = "premise";
         ln.pRefs = {-1};
+        ln.pRuleCategory = -1;
+        ln.pRuleIndex    = -1;
         if (!mLines->setLineAt(row, ln)) return false;
-        emit dataChanged(index(row, 0), index(row, 0), {TypeRole, RefsRole});
+        emit dataChanged(index(row, 0), index(row, 0), {TypeRole, RefsRole, RuleCategoryRole, RuleIndexRole});
         recomputePremiseCount();
     }
     return true;

--- a/qt/proofmodel.cpp
+++ b/qt/proofmodel.cpp
@@ -165,16 +165,19 @@ void ProofModel::setlines(ProofData *newLines)
         });
         connect(mLines,&ProofData::postLineInsert,this,[=](){
             endInsertRows();
+            recomputePremiseCount();
         });
         connect(mLines,&ProofData::preLineRemove,this,[=](int index){
             beginRemoveRows(QModelIndex(),index,index);
         });
         connect(mLines,&ProofData::postLineRemove,this,[=](){
             endRemoveRows();
+            recomputePremiseCount();
         });
     }
 
     endResetModel();
+    recomputePremiseCount();
 }
 
 // TODO: Use model indices directly in QML, no need to update lines that way
@@ -242,7 +245,7 @@ void ProofModel::setPremiseCount(int n)
 }
 
 // Toggle a single row between "premise" and "choose".
-// Also clears the row's refs to {-1} and adjusts mPremiseCount by ±1.
+// Clears the row's refs to {-1} and recomputes premiseCount from data.
 // Returns false if the row is out of range or is a subproof/sf line.
 bool ProofModel::toggleLineType(int row)
 {
@@ -260,14 +263,14 @@ bool ProofModel::toggleLineType(int row)
         ln.pRefs = {-1};
         if (!mLines->setLineAt(row, ln)) return false;
         emit dataChanged(index(row, 0), index(row, 0), {TypeRole, RefsRole});
-        setPremiseCount(mPremiseCount - 1);
+        recomputePremiseCount();
     } else {
         // Any non-premise, non-subproof type → "premise"
         ln.pType = "premise";
         ln.pRefs = {-1};
         if (!mLines->setLineAt(row, ln)) return false;
         emit dataChanged(index(row, 0), index(row, 0), {TypeRole, RefsRole});
-        setPremiseCount(mPremiseCount + 1);
+        recomputePremiseCount();
     }
     return true;
 }

--- a/qt/proofmodel.h
+++ b/qt/proofmodel.h
@@ -40,7 +40,9 @@ public:
         SubEndRole,
         IndentRole,
         RefsRole,
-        ErrorRole      // carries pErrorMsg — "errMsg" in QML
+        ErrorRole,      // carries pErrorMsg — "errMsg" in QML
+        RuleCategoryRole,   // int 0-4 — locale-invariant outer combo index
+        RuleIndexRole       // int 0-N — locale-invariant inner combo index
     };
 
     // Basic functionality:
@@ -77,6 +79,12 @@ private:
     void setPremiseCount(int n);
     ProofData *mLines;
     int  mPremiseCount = 1;
+
+    static QString canonicalName(int cat, int idx);
+
+    // Returns a map from canonical English rule name -> {cat, idx}.
+    struct RulePos { int cat; int idx; };
+    static const QHash<QString, RulePos> &rulePosMap();
 };
 
 #endif // PROOFMODEL_H

--- a/qt/proofmodel.h
+++ b/qt/proofmodel.h
@@ -25,7 +25,7 @@ class ProofModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY(ProofData* lines READ lines WRITE setlines)
-    Q_PROPERTY(int premiseCount READ premiseCount WRITE setPremiseCount
+    Q_PROPERTY(int premiseCount READ premiseCount
                NOTIFY premiseCountChanged)
 
 public:
@@ -62,23 +62,19 @@ public:
     Q_INVOKABLE void updateRefs(int ln, bool op);
     Q_INVOKABLE void clearErrors();  // reset ErrorRole on every row
 
-    // premiseCount — single source of truth for the premise/conclusion boundary.
+    // premiseCount — computed from the model data; read-only from QML.
     int  premiseCount() const;
-    void setPremiseCount(int n);
 
-    // Toggle a line between "premise" and "choose", clear its refs, and update
-    // premiseCount atomically.  Returns false if the row is out of range or the
-    // line is a subproof/sf line.
+    
     Q_INVOKABLE bool toggleLineType(int row);
 
-    // Rescan all rows and recompute premiseCount from scratch.  Call this after
-    // opening or importing a file so the counter is always in sync with the data.
     Q_INVOKABLE void recomputePremiseCount();
 
 signals:
     void premiseCountChanged(int n);
 
 private:
+    void setPremiseCount(int n);
     ProofData *mLines;
     int  mPremiseCount = 1;
 };

--- a/qt/settings.cpp
+++ b/qt/settings.cpp
@@ -32,4 +32,5 @@ void Settings::setLanguage(const QString& languageCode)
     }
 
     m_engine->retranslate();
+    emit languageChanged();
 }

--- a/qt/settings.h
+++ b/qt/settings.h
@@ -17,6 +17,9 @@ public:
 
     Q_INVOKABLE void setLanguage(const QString& languageCode);
 
+signals:
+    void languageChanged();
+
 private:
     QGuiApplication *m_app;
     QQmlEngine *m_engine;

--- a/src/aris.c
+++ b/src/aris.c
@@ -242,6 +242,22 @@ there are invalid quantifiers in the string - '%s'\n", arg_text);
       fprintf (stderr, "Text Error - \
 there are syntactical errors in the string - '%s'\n", arg_text);
       return 0;
+    case -6:
+      fprintf (stderr, "Text Error - \
+predicate names must start with an uppercase letter in the string - '%s'\n", arg_text);
+      return 0;
+    case -7:
+      fprintf (stderr, "Text Error - \
+term/variable names must start with a lowercase letter in the string - '%s'\n", arg_text);
+      return 0;
+    case -8:
+      fprintf (stderr, "Text Error - \
+invalid symbol characters or empty argument list in the string - '%s'\n", arg_text);
+      return 0;
+    case -9:
+      fprintf (stderr, "Text Error - \
+ambiguous chaining of ->, <->, or XOR without parentheses in the string - '%s'\n", arg_text);
+      return 0;
     }
 
   return 1;

--- a/src/aris.c
+++ b/src/aris.c
@@ -255,7 +255,7 @@ there are syntactical errors in the string - '%s'\n", arg_text);
  *    -1 on memory error.
  */
 int
-grade_file (proof_t * c_file)
+grade_file (proof_t * c_file, struct connectives_list conns)
 {
   int ret_chk, grade;
   vec_t * rets;
@@ -266,7 +266,7 @@ grade_file (proof_t * c_file)
   if (!rets)
     return -1;
 
-  ret_chk = proof_eval (c_file, rets, 0);
+  ret_chk = proof_eval (c_file, rets, 0, conns);
   if (ret_chk == -1)
     return -1;
 
@@ -790,7 +790,7 @@ a conclusion must be specified in evaluation mode.\n");
                 {
                   if (verbose)
                     printf ("Grading file: '%s'\n", file_name[c]);
-                  g = grade_file (proof[c]);
+                  g = grade_file (proof[c], cli_conns);
                   if (g == -1)
                     exit (EXIT_FAILURE);
                   printf ("\n");
@@ -802,7 +802,7 @@ a conclusion must be specified in evaluation mode.\n");
           for (c = 0; c < cur_file; c++)
             {
               int ret_chk;
-              ret_chk = proof_eval (proof[c], NULL, verbose);
+              ret_chk = proof_eval (proof[c], NULL, verbose, cli_conns);
               if (ret_chk == -1)
                 exit (EXIT_FAILURE);
             }

--- a/src/process.c
+++ b/src/process.c
@@ -999,8 +999,8 @@ check_generalities (unsigned char * text)
             if (ret_chk == AEC_MEM)
                 return AEC_MEM;
 
-            if (ret_chk == -2)
-                return -5;
+            if (ret_chk == -2 || ret_chk < -5)
+                return ret_chk == -2 ? -5 : ret_chk;
 
             return 0;
         }
@@ -1029,8 +1029,8 @@ check_generalities (unsigned char * text)
         if (ret_chk == AEC_MEM)
             return AEC_MEM;
 
-        if (ret_chk == -2)
-            return -5;
+        if (ret_chk == -2 || ret_chk < -5)
+            return ret_chk == -2 ? -5 : ret_chk;
 
         return 0;
     }
@@ -1045,9 +1045,9 @@ check_generalities (unsigned char * text)
     {
         if (!strcmp (conn, CON) || !strcmp (conn, BIC) || !strcmp (conn, XOR))
         {
-            // Connective Error.
+            // Connective Error: Ambiguous non-associative chaining
             destroy_str_vec (gens);
-            return -3;
+            return -9;
         }
     }
 
@@ -1101,12 +1101,12 @@ check_symbols (unsigned char * in_str, int pred)
             return 0;
 
         if (!isupper (in_str[0]))
-            return -2;
+            return -6;
     }
     else
     {
         if (!islower (in_str[0]) && !isdigit (in_str[0]))
-            return -2;
+            return -7;
     }
 
     int pos = 1;
@@ -1114,7 +1114,7 @@ check_symbols (unsigned char * in_str, int pred)
     while (in_str[pos] != '(' && in_str[pos] != '\0')
     {
         if (!ISLEGIT (in_str[pos]))
-            return -2;
+            return -8;
 
         pos++;
     }
@@ -1125,7 +1125,7 @@ check_symbols (unsigned char * in_str, int pred)
     pos++;
 
     if (in_str[pos] == ')')
-        return -2;
+        return -8;
 
     int cur_pos;
 
@@ -1178,8 +1178,8 @@ check_symbols (unsigned char * in_str, int pred)
                     return AEC_MEM;
 
                 free (tmp_str);
-                if (ret_chk == -2)
-                    return -2;
+                if (ret_chk < 0)
+                    return ret_chk;
                 done = 1;
                 if (in_str[cur_pos] == ',')
                     cur_pos++;

--- a/src/process.c
+++ b/src/process.c
@@ -27,8 +27,6 @@
 #include <math.h>
 
 
-struct connectives_list main_conns;
-
 struct connectives_list main_conns = { 0 };
 
 /* Eliminates a negation from a string.

--- a/src/proof.c
+++ b/src/proof.c
@@ -77,12 +77,17 @@ proof_destroy (proof_t * proof)
  *    proof - The proof that is being evaluated.
  *    rets - A vector to store the return values.
  *    verbose - A flag denoting verbosity.
+ *    conns - The connectives set to use for this evaluation.
  *  output:
  *    0 on success, -1 on memory error.
  */
 int
-proof_eval (proof_t * proof, vec_t * rets, int verbose)
+proof_eval (proof_t * proof, vec_t * rets, int verbose, struct connectives_list conns)
 {
+    /* Centralise the single write to main_conns: callers pass in the
+       connectives they need instead of mutating the global themselves. */
+    main_conns = conns;
+
     int rc;
     rc = eval_proof (proof->everything, rets, verbose);
 

--- a/src/proof.h
+++ b/src/proof.h
@@ -23,6 +23,7 @@
 extern "C" {
 #endif
 #include "typedef.h"
+#include "process.h"
 
 // Proof data structure.
 
@@ -34,7 +35,7 @@ struct proof {
 
 proof_t * proof_init ();
 void proof_destroy (proof_t * proof);
-int proof_eval (proof_t * proof, vec_t * rets, int verbose);
+int proof_eval (proof_t * proof, vec_t * rets, int verbose, struct connectives_list conns);
 int eval_proof (list_t * everything, vec_t * rets, int verbose);
 
 int convert_proof_latex (proof_t * proof, const char * filename);

--- a/src/sen-data.c
+++ b/src/sen-data.c
@@ -278,7 +278,7 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
         else
         {
             *ret_val = VALUE_TYPE_ERROR;
-            return _("Only the first sentence can be blank.");
+            return _("Only line 1 can be blank; subsequent blank lines are not allowed.");
         }
     }
 
@@ -297,13 +297,21 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
     case 0:
         break;
     case -2:
-        return _("The sentence has mismatched parenthesis.");
+        return _("Syntax Error: Mismatched parentheses. Check opening and closing brackets.");
     case -3:
-        return _("The sentence has invalid connectives.");
+        return _("Syntax Error: Unrecognized or invalid logical connective symbol.");
     case -4:
-        return _("The sentence has invalid quantifiers.");
+        return _("Syntax Error: Unrecognized or invalid quantifier symbol.");
     case -5:
-        return _("The sentence has syntactical errors.");
+        return _("Syntax Error: The sentence has syntactical errors.");
+    case -6:
+        return _("Syntax Error: Predicate or propositional variable names must start with an uppercase letter (A-Z).");
+    case -7:
+        return _("Syntax Error: Individual terms and variables must start with a lowercase letter (a-z) or number.");
+    case -8:
+        return _("Syntax Error: Invalid characters in symbol name or empty argument parentheses '()'.");
+    case -9:
+        return _("Syntax Error: Chaining conditionals (->), biconditionals (<->), or XOR without enclosing parentheses is ambiguous.");
     }
 
     *ret_val = VALUE_TYPE_BLANK;
@@ -317,7 +325,7 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
     if (sd->rule == -1 || sd->rule >= NUM_RULES)
     {
         *ret_val = VALUE_TYPE_RULE;
-        return _("The sentence is missing a rule.");
+        return _("Missing Rule: Please select a justification rule for this proof line.");
     }
 
     *ret_val = VALUE_TYPE_ERROR;
@@ -338,7 +346,7 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
         {
             destroy_str_vec (refs);
             *ret_val = VALUE_TYPE_ERROR;
-            return _("A referenced line does not exist in this proof.");
+            return _("Invalid Reference: One or more referenced line numbers do not exist in this proof.");
         }
 
         cur_ref = ls_nth (lines, sd->refs[i] - 1);
@@ -356,7 +364,7 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
             destroy_str_vec (refs);
             *ret_val = VALUE_TYPE_REF;
 
-            return _("One of the sentence's references has a text error.");
+            return _("Invalid Reference: A referenced line has a syntax or evaluation error. First fix the error on that line.");
         }
 
         unsigned char * ref_text;
@@ -396,7 +404,7 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
                 {
                     *ret_val = VALUE_TYPE_REF;
                     destroy_str_vec (refs);
-                    return _("One of the sentence's references has a text error.");
+                    return _("Invalid Reference: A referenced line has a syntax or evaluation error. First fix the error on that line.");
                 }
 
                 unsigned char * ref_text;
@@ -408,7 +416,7 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
             }
             else if (sd->rule == RULE_SP)
             {
-                return _("\'sp\' can only be used with a subproof as a reference.");
+                return _("Rule 'sp' (Subproof) can only reference the starting line of a subproof.");
             }
         }
     }
@@ -463,7 +471,7 @@ sen_data_evaluate (sen_data * sd, int * ret_val, list_t * pf_vars, list_t * line
                 *ret_val = VALUE_TYPE_ERROR;
                 destroy_str_vec (refs);
                 destroy_vec (vars);
-                return _("Unable to open lemma file.");
+                return _("File Error: Unable to open or read the specified lemma file.");
             }
 
             main_conns = current_conns;

--- a/src/sexpr-process-bool.c
+++ b/src/sexpr-process-bool.c
@@ -63,7 +63,7 @@ process_bool (unsigned char * conc, vec_t * prems, const char * rule)
   if (!strcmp (rule, "sn"))
     {
       if (prems->num_stuff != 1)
-    return _("Symbol Negation require one (1) reference.");
+    return _("Symbol Negation requires exactly one (1) reference.");
 
       prem = vec_nth (prems, 0);
       ret = proc_sn (*prem, conc);
@@ -98,7 +98,7 @@ proc_bi (unsigned char * prem, unsigned char * conc)
     {
       si--;
       if (si < 0)
-    return _("Boolean Identity constructed incorrectly.");
+    return _("Boolean Identity Error: Expected simplification or expansion with True/False constants.");
     }
   else if (si > 0
        && (!strncmp (sh_sen + si - 1, S_AND, S_CL)
@@ -133,7 +133,7 @@ proc_bi (unsigned char * prem, unsigned char * conc)
     return NULL;
 
       if (li < 0)
-    return _("Boolean Identity constructed incorrectly.");
+    return _("Boolean Identity Error: Expected simplification or expansion with True/False constants.");
 
       if (si < 0)
     {
@@ -144,7 +144,7 @@ proc_bi (unsigned char * prem, unsigned char * conc)
     }
 
   if (ln_sen[li] != '(')
-    return _("Boolean Identity constructed incorrectly.");
+    return _("Boolean Identity Error: Expected simplification or expansion with True/False constants.");
 
   int tmp_pos;
   unsigned char * tmp_str;
@@ -232,7 +232,7 @@ with a disjunction.");
   if (ret_str == NO_DIFFERENCE || ret_str == CORRECT)
     return CORRECT;
 
-  return _("Boolean Identity constructed incorrectly.");
+  return _("Boolean Identity Error: Expected simplification or expansion with True/False constants.");
 }
 
 char *
@@ -336,7 +336,7 @@ proc_bd (unsigned char * prem, unsigned char * conc)
   if (ret_str == NO_DIFFERENCE || ret_str == CORRECT)
     return CORRECT;
 
-  return _("Boolean Dominance constructed incorrectly.");
+  return _("Boolean Dominance Error: Expected absorption with True/False constants.");
 }
 
 char *
@@ -423,7 +423,7 @@ proc_bn (unsigned char * prem, unsigned char * conc)
   if (ret_str == NO_DIFFERENCE || ret_str == CORRECT)
     return CORRECT;
 
-  return _("Boolean Negation constructed incorrectly.");
+  return _("Boolean Negation Error: Expected complementary cancellation or constant negation.");
 }
 
 char *
@@ -491,5 +491,5 @@ proc_sn (unsigned char * prem, unsigned char * conc)
   if (ret_str == NO_DIFFERENCE || ret_str == CORRECT)
     return CORRECT;
 
-  return _("Symbol Negation constructed incorrectly.");
+  return _("Symbol Negation Error: Expected negation of a Boolean constant symbol.");
 }

--- a/src/sexpr-process-equiv.c
+++ b/src/sexpr-process-equiv.c
@@ -372,7 +372,7 @@ proc_im (unsigned char * prem, unsigned char * conc)
     // Only occurs if there is no top connective on one, or a quantifier.
 
     if (i < 2)
-        return _("Implication constructed incorrectly.");
+        return _("Implication Error: Expected equivalence between a conditional (P -> Q) and a disjunction (~P v Q).");
 
     int tmp_pos;
     unsigned char * tmp_str;
@@ -381,7 +381,7 @@ proc_im (unsigned char * prem, unsigned char * conc)
     if (tmp_pos == AEC_MEM)
         return NULL;
     if (!tmp_str)
-        return _("Implication constructed incorrectly.");
+        return _("Implication Error: Expected equivalence between a conditional (P -> Q) and a disjunction (~P v Q).");
 
     int ftc;
     unsigned char * lsen, * rsen, * n_lsen;
@@ -435,7 +435,7 @@ proc_im (unsigned char * prem, unsigned char * conc)
     if (ret_str == NO_DIFFERENCE || ret_str == CORRECT)
         return CORRECT;
 
-    return _("Implication constructed incorrectly.");
+    return _("Implication Error: Expected equivalence between a conditional (P -> Q) and a disjunction (~P v Q).");
 }
 
 char *
@@ -470,7 +470,7 @@ proc_dm (unsigned char * prem, unsigned char * conc, int mode_guess)
         int n_len;
 
         if (i == 0)
-            return _("DeMorgan constructed incorrectly.");
+            return _("DeMorgan Error: Expected equivalence when distributing negation across conjunction or disjunction.");
 
         if (!strncmp (prem + i - 1, S_NOT, S_NL))
         {
@@ -496,7 +496,7 @@ proc_dm (unsigned char * prem, unsigned char * conc, int mode_guess)
         if (tmp_pos == AEC_MEM)
             return NULL;
         if (!tmp_str)
-            return _("DeMorgan constructed incorrectly.");
+            return _("DeMorgan Error: Expected equivalence when distributing negation across conjunction or disjunction.");
 
         unsigned char * elim_sen;
 
@@ -522,7 +522,7 @@ proc_dm (unsigned char * prem, unsigned char * conc, int mode_guess)
         if (gg == 1)
         {
             destroy_str_vec (gg_vec);
-            return _("There must be generalities on the negation sentence.");
+            return _("DeMorgan Quantifier Error: Expected a quantifier on the negated statement.");
         }
 
         if (strcmp (conn, S_AND) && strcmp (conn, S_OR))
@@ -984,7 +984,7 @@ proc_dt (unsigned char * prem, unsigned char * conc, int mode_guess)
             && (strcmp (quant, S_EXL) || strcmp (conn, S_OR)))
         {
             destroy_str_vec (gg_vec);
-            return _("A universal is distributed over a conjnction, and an existential is distributed over a disjunction.");
+            return _("Distribution Error: A universal quantifier is distributed over a conjunction, and an existential quantifier is distributed over a disjunction.");
         }
 
         unsigned char * oth_sen;

--- a/src/sexpr-process-infer.c
+++ b/src/sexpr-process-infer.c
@@ -41,7 +41,7 @@ process_inference (unsigned char * conc, vec_t * prems, const char * rule)
     if (!strcmp (rule, "ad"))
     {
         if (prems->num_stuff != 1)
-            return _("Addition requires one (1) references.");
+            return _("Addition requires one (1) reference.");
 
         unsigned char * prem;
         prem = vec_str_nth (prems, 0);
@@ -89,7 +89,7 @@ process_inference (unsigned char * conc, vec_t * prems, const char * rule)
     if (!strcmp (rule, "ds"))
     {
         if (prems->num_stuff < 2)
-            return _("Disjunctive Syllogism requires at least two (2) arguemnts.");
+            return _("Disjunctive Syllogism requires at least two (2) references.");
 
         ret = proc_ds (prems, conc);
         if (!ret)
@@ -163,7 +163,7 @@ proc_mp (unsigned char * prem_0, unsigned char * prem_1, unsigned char * conc)
         if (lsen) free (lsen);
         if (rsen) free (rsen);
 
-        return _("The top connective must be a conditional.");
+        return _("Modus Ponens Error: One of the references must be a conditional statement (->).");
     }
 
     int ant_eq, con_eq;
@@ -174,11 +174,14 @@ proc_mp (unsigned char * prem_0, unsigned char * prem_1, unsigned char * conc)
     free (lsen);
     free (rsen);
 
+    if (!ant_eq && !con_eq)
+        return _("Modus Ponens Error: Neither the antecedent nor the consequence of the conditional matches the premise or conclusion. Check your references and line order.");
+
     if (!ant_eq)
-        return _("The antecedent of the conditional reference must be the other reference.");
+        return _("Modus Ponens Error: The antecedent of the conditional (->) does not match the minor premise reference.");
 
     if (!con_eq)
-        return _("The consequence of the conditional reference must be the conclusion.");
+        return _("Modus Ponens Error: The consequence of the conditional (->) does not match the conclusion.");
 
     return CORRECT;
 }
@@ -291,7 +294,7 @@ proc_cn (vec_t * prems, unsigned char * conc)
     case -3:
         return _("One of the conjuncts in the conclusion does not match up with a reference.");
     }
-    return _("Error");
+    return _("Conjunction Error: The referenced conjuncts do not match the conclusion.");
 }
 
 char *
@@ -509,7 +512,7 @@ proc_ds (vec_t * prems, unsigned char * conc)
     case -3:
         return _("One of the references or conclusion does not match up with a disjunct.");
     }
-    return _("Error with Disjunctive Syllogism.");
+    return _("Disjunctive Syllogism Error: The referenced disjunction or negation does not match the conclusion.");
 }
 
 char *
@@ -645,7 +648,7 @@ proc_cd (vec_t * prems, unsigned char * conc)
         destroy_str_vec (conc_gg_vec);
         destroy_str_vec (ants);
         destroy_str_vec (cons);
-        return _("Constructive Dilemma constructed incorrectly.");
+        return _("Constructive Dilemma Error: The structure of the conditionals or disjunctions does not match.");
     }
 
     int ants_ret_chk, cons_ret_chk;
@@ -683,7 +686,7 @@ proc_cd (vec_t * prems, unsigned char * conc)
     case -3:
         return _("One of the consequences did not match a disjunct from the conclusion.");
     }
-    return _("Error with Constructive Dilemma.");
+    return _("Constructive Dilemma Error: The antecedents or consequences do not correspond to the conclusion's disjuncts.");
 }
 
 /* XOR Introduction (xi).

--- a/src/sexpr-process-misc.c
+++ b/src/sexpr-process-misc.c
@@ -275,7 +275,7 @@ process_misc (unsigned char * conc, vec_t * prems, const char * rule, vec_t * va
     if (!strcmp (rule, "sp"))
     {
         if (prems->num_stuff < 2)
-            return _("Subproof requires a subproof as a reference.");
+            return _("Subproof Error: The rule 'sp' requires a subproof line as a reference.");
 
         unsigned char * prem_0, * prem_1;
 
@@ -350,7 +350,7 @@ proc_lm (vec_t * prems, unsigned char * conc, proof_t * proof)
     if (num_pf_refs != prems->num_stuff)
     {
         destroy_str_vec (pf_sens);
-        return _("Lemma requires the same amount of references as the amount of premises in the proof.");
+        return _("Lemma Error: The number of references provided must exactly match the number of premises required by the lemma.");
     }
 
     for (itr = proof->goals->head; itr; itr = itr->next)
@@ -393,7 +393,7 @@ proc_lm (vec_t * prems, unsigned char * conc, proof_t * proof)
 
         if (!ret_chk)
             return CORRECT;
-        return _("Incorrect usage of lemma.");
+        return _("Lemma Error: The referenced lemma does not match the premises or conclusion required by this line.");
     }
 
     int valid, cur_len, pf_len;
@@ -500,7 +500,7 @@ proc_sp (unsigned char * prem_0, unsigned char * prem_1, unsigned char * conc)
     free (rsen);
 
     if (!cmp_0 || !cmp_1)
-        return _("The premise of the subproof must be the antecedent, and the conclusion must be the consequence.");
+        return _("Subproof Error: The premise of the subproof must match the conditional's antecedent, and the subproof conclusion must match the consequence.");
 
     return CORRECT;
 }
@@ -781,5 +781,5 @@ proc_in (unsigned char * prem_0, unsigned char * prem_1, unsigned char * conc, v
 
     if (chk)
         return CORRECT;
-    return _("Induction constructed incorrectly.");
+    return _("Induction Error: The base case or inductive step does not match the universal conclusion.");
 }

--- a/src/sexpr-process-quant.c
+++ b/src/sexpr-process-quant.c
@@ -114,7 +114,7 @@ process_quantifiers (unsigned char * conc, vec_t * prems, const char * rule, vec
     if (!strcmp (rule, "ug"))
     {
         if (prems->num_stuff != 1)
-            return _("Universal Generalization requires one (1) references.");
+            return _("Universal Generalization requires exactly one (1) reference.");
 
         ret = proc_ug (prem, conc, vars);
         if (!ret)
@@ -124,7 +124,7 @@ process_quantifiers (unsigned char * conc, vec_t * prems, const char * rule, vec
     if (!strcmp (rule, "ui"))
     {
         if (prems->num_stuff != 1)
-            return _("Universal Instantiation requires one (1) reference.");
+            return _("Universal Instantiation requires exactly one (1) reference.");
 
         ret = proc_ui (prem, conc);
         if (!ret)
@@ -134,7 +134,7 @@ process_quantifiers (unsigned char * conc, vec_t * prems, const char * rule, vec
     if (!strcmp (rule, "eg"))
     {
         if (prems->num_stuff != 1)
-            return _("Existential Generalization requires one (1) reference.");
+            return _("Existential Generalization requires exactly one (1) reference.");
 
         ret = proc_eg (prem, conc);
         if (!ret)
@@ -144,7 +144,7 @@ process_quantifiers (unsigned char * conc, vec_t * prems, const char * rule, vec
     if (!strcmp (rule, "ei"))
     {
         if (prems->num_stuff != 1)
-            return _("Existential Instantiation requires one (1) references.");
+            return _("Existential Instantiation requires exactly one (1) reference.");
 
         ret = proc_ei (prem, conc, vars);
         if (!ret)
@@ -194,7 +194,7 @@ process_quantifiers (unsigned char * conc, vec_t * prems, const char * rule, vec
     if (!strcmp (rule, "fv"))
     {
         if (prems->num_stuff != 2)
-            return _("Free Variable requires one two (2) references.");
+            return _("Free Variable Substitution requires one or two (1 or 2) references.");
 
         unsigned char * prem_0;
         prem_0 = vec_str_nth (prems, 1);
@@ -219,7 +219,7 @@ proc_ug (unsigned char * prem, unsigned char * conc, vec_t * vars)
     if (ret_chk == 0)
         return CORRECT;
     else if (ret_chk == -3)
-        return _("The variable must be arbitrary.");
+        return _("Universal Generalization Error: The generalized variable must be arbitrary (not introduced by Existential Instantiation or unclosed assumptions).");
     else
         return _("Universal Generalization constructed incorrectly.");
 }
@@ -263,7 +263,7 @@ proc_ei (unsigned char * prem, unsigned char * conc, vec_t * vars)
     if (ret_chk == 0)
         return CORRECT;
     else if (ret_chk == -3)
-        return _("The variable must not have been used.");
+        return _("Existential Instantiation Error: The instantiated variable must be completely new and not previously used in the proof.");
     else
         return _("Existential Instantiation constructed incorrectly.");
 }


### PR DESCRIPTION
Description
This PR contains 7 commits that clean up duplication in the core bridge, fix rule selection loss on language switches, and implement robust error surfacing and state-tracking across QML and the C++ engine.

Commit Walkthrough
**1. 47ebdf1: Remove duplicate main_conns definition and decouple Qt bridge from C**

- Eliminated duplicate declarations of main_conns that caused linker collisions. Decoupled the Qt C++ bridge layers from global C engine variables, establishing a cleaner interface boundaries and preventing build-time redeclaration warnings.

**2. 1b7c74c: Centralize premiseCount as a dynamically derived property driven by model**

- Replaced manual, error-prone synchronization of premiseCount across layers. It is now dynamically derived directly from the underlying data model, ensuring that premises and conclusion indices are always mathematically aligned in the UI.

**3. 5a9c9e1: Surface file open and save failures in UI status bar via errorOccurred**

- Wired up backend file system failures (e.g., directory permission blocks or missing files during open/save operations) to propagate from C++ to QML. The error is routed through the errorOccurred signal and printed as a red footer status bar warning instead of failing silently in C++.

**4. 814771f: Fix rule selection loss on language change using locale-invariant categories**

- Introduced two locale-invariant integer properties (pRuleCategory and pRuleIndex) inside ProofLine. Instead of matching strings dynamically when changing languages (which broke selection on translation refresh), the UI now maps selections directly to these integer indices.

**5. 6db2928: Fix off-by-one QML model role IDs causing rule selections to be discarded**

- Resolved critical off-by-one role mismatch errors (Roles 265 and 266) in ProofModel mapping callbacks that caused newly loaded file values to be silently discarded.

**6. c767a7f: Enhance UI translation refresh, unsaved modification tracking, and autosave**

- Implemented an immediate translation refresh call on Settings::languageChanged without requiring a program restart.
- Added fileModified flags to all interactive text inputs and dropdowns to trigger warning modals if the user tries to exit with unsaved changes.

Added instant WASM-based autosave debounce states to prevent state losses on browser page reloads.
**7. a095648: Improve syntax error propagation, fix rule selection reset, and surface warnings**

- Refactored check_generalities and check_symbols inside the parser engine (src/process.c) to propagate granular syntax codes (e.g., -6 to -9 for predicate naming, empty parentheses, and ambiguous non-associative chaining) and translated them to user-friendly warnings in src/sen-data.c.
- Added a delegate-level Connections block to ensure QML restores combobox index selections cleanly on language switch.
- Surfaced silent qDebug errors for malformed goals and LaTeX export/proof import failures to the status bar.