### PR TITLE
UX improvements: Export formats, collapsible subproofs, macros, and fixes

### DIFF
--- a/doc/proofs/boolean/pf-bd.tle
+++ b/doc/proofs/boolean/pf-bd.tle
@@ -9,7 +9,7 @@
   <entry n="2" t="C | !"/>
  </premises>
  <conclusions>
-  <entry n="3" l="33" r="1" d="0" t="^"/>
-  <entry n="4" l="33" r="2" d="0" t="!"/>
+  <entry n="3" l="36" r="1" d="0" t="^"/>
+  <entry n="4" l="36" r="2" d="0" t="!"/>
  </conclusions>
 </proof>

--- a/doc/proofs/boolean/pf-bi.tle
+++ b/doc/proofs/boolean/pf-bi.tle
@@ -9,7 +9,7 @@
   <entry n="2" t="A | ^"/>
  </premises>
  <conclusions>
-  <entry n="3" l="31" r="1" d="0" t="B"/>
-  <entry n="4" l="31" r="2" d="0" t="A"/>
+  <entry n="3" l="34" r="1" d="0" t="B"/>
+  <entry n="4" l="34" r="2" d="0" t="A"/>
  </conclusions>
 </proof>

--- a/doc/proofs/boolean/pf-bn.tle
+++ b/doc/proofs/boolean/pf-bn.tle
@@ -9,7 +9,7 @@
   <entry n="2" t="B | ~B"/>
  </premises>
  <conclusions>
-  <entry n="3" l="32" r="1" d="0" t="^"/>
-  <entry n="4" l="32" r="2" d="0" t="!"/>
+  <entry n="3" l="35" r="1" d="0" t="^"/>
+  <entry n="4" l="35" r="2" d="0" t="!"/>
  </conclusions>
 </proof>

--- a/doc/proofs/boolean/pf-sn.tle
+++ b/doc/proofs/boolean/pf-sn.tle
@@ -9,7 +9,7 @@
   <entry n="2" t="~!"/>
  </premises>
  <conclusions>
-  <entry n="3" l="34" r="1" d="0" t="!"/>
-  <entry n="4" l="34" r="2" d="0" t="^"/>
+  <entry n="3" l="37" r="1" d="0" t="!"/>
+  <entry n="4" l="37" r="2" d="0" t="^"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-as.tle
+++ b/doc/proofs/equivalence/pf-as.tle
@@ -11,9 +11,9 @@
   <entry n="2" t="X | Y | Z | W | J | K  ;; Next, using disjunctions"/>
  </premises>
  <conclusions>
-  <entry n="3" l="10" r="1" d="0" t="A &amp; B &amp; C &amp; D &amp; E &amp; F"/>
-  <entry n="4" l="10" r="3" d="0" t="(A &amp; B &amp; C) &amp; (D &amp; E &amp; F)"/>
-  <entry n="5" l="10" r="2" d="0" t="(X | Y | Z) | (W | (J | K))"/>
-  <entry n="6" l="10" r="2" d="0" t="((X | Y) | Z) | (W | J | K)"/>
+  <entry n="3" l="12" r="1" d="0" t="A &amp; B &amp; C &amp; D &amp; E &amp; F"/>
+  <entry n="4" l="12" r="3" d="0" t="(A &amp; B &amp; C) &amp; (D &amp; E &amp; F)"/>
+  <entry n="5" l="12" r="2" d="0" t="(X | Y | Z) | (W | (J | K))"/>
+  <entry n="6" l="12" r="2" d="0" t="((X | Y) | Z) | (W | J | K)"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-co.tle
+++ b/doc/proofs/equivalence/pf-co.tle
@@ -11,10 +11,10 @@
   <entry n="2" t="P &amp; Q &amp; R  ;; Next, conjunctions."/>
  </premises>
  <conclusions>
-  <entry n="3" l="11" r="1" d="0" t="(B | C) | A"/>
-  <entry n="4" l="11" r="3" d="0" t="(C | B) | A"/>
-  <entry n="5" l="11" r="1" d="0" t="A | (C | B)"/>
-  <entry n="6" l="11" r="2" d="0" t="R &amp; P &amp; Q"/>
-  <entry n="7" l="11" r="1" d="0" t="(C | B) | A ;; This one isn't supposed to work.&#10;&#9;Since the top two parts were already flipped, recursion doesn't work."/>
+  <entry n="3" l="13" r="1" d="0" t="(B | C) | A"/>
+  <entry n="4" l="13" r="3" d="0" t="(C | B) | A"/>
+  <entry n="5" l="13" r="1" d="0" t="A | (C | B)"/>
+  <entry n="6" l="13" r="2" d="0" t="R &amp; P &amp; Q"/>
+  <entry n="7" l="13" r="1" d="0" t="(C | B) | A ;; This one isn't supposed to work.&#10;&#9;Since the top two parts were already flipped, recursion doesn't work."/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-dm.tle
+++ b/doc/proofs/equivalence/pf-dm.tle
@@ -17,12 +17,12 @@
   <entry n="6" t="~#z(P(z) | Q(z)) ; A more complicated version."/>
  </premises>
  <conclusions>
-  <entry n="7" l="9" r="1" d="0" t="~A | ~B"/>
-  <entry n="8" l="9" r="2" d="0" t="~~A &amp; ~B"/>
-  <entry n="9" l="9" r="3" d="0" t="~(C | D)"/>
-  <entry n="10" l="9" r="4" d="0" t="A(a) &amp; (~C(a) &amp; ~D(a))"/>
-  <entry n="11" l="9" r="5" d="0" t="#x(~P(x))"/>
-  <entry n="12" l="9" r="6" d="0" t="@z(~(P(z) | Q(z)))"/>
-  <entry n="13" l="9" r="12" d="0" t="@z(~P(z) &amp; ~Q(z))"/>
+  <entry n="7" l="11" r="1" d="0" t="~A | ~B"/>
+  <entry n="8" l="11" r="2" d="0" t="~~A &amp; ~B"/>
+  <entry n="9" l="11" r="3" d="0" t="~(C | D)"/>
+  <entry n="10" l="11" r="4" d="0" t="A(a) &amp; (~C(a) &amp; ~D(a))"/>
+  <entry n="11" l="11" r="5" d="0" t="#x(~P(x))"/>
+  <entry n="12" l="11" r="6" d="0" t="@z(~(P(z) | Q(z)))"/>
+  <entry n="13" l="11" r="12" d="0" t="@z(~P(z) &amp; ~Q(z))"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-dn.tle
+++ b/doc/proofs/equivalence/pf-dn.tle
@@ -10,8 +10,8 @@
   <entry n="2" t="D &amp; N  ;; Operating on a sentence part."/>
  </premises>
  <conclusions>
-  <entry n="3" l="15" r="1" d="0" t="~~~~~~D"/>
-  <entry n="4" l="15" r="3" d="0" t="~~D"/>
-  <entry n="5" l="15" r="2" d="0" t="~~D &amp; ~~~~~~N"/>
+  <entry n="3" l="17" r="1" d="0" t="~~~~~~D"/>
+  <entry n="4" l="17" r="3" d="0" t="~~D"/>
+  <entry n="5" l="17" r="2" d="0" t="~~D &amp; ~~~~~~N"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-dt.tle
+++ b/doc/proofs/equivalence/pf-dt.tle
@@ -14,10 +14,10 @@
   <entry n="4" t="A(a) $ (B(b) &amp; (C(b) | D(b)))  ;; A little more complex"/>
  </premises>
  <conclusions>
-  <entry n="5" l="13" r="1" d="0" t="(A &amp; B) | (A &amp; C)"/>
-  <entry n="6" l="13" r="5" d="0" t="((A &amp; B) | A) &amp; ((A &amp; B) | C)"/>
-  <entry n="7" l="13" r="2" d="0" t="#x(P(x)) | #x(Q(x)) | #x(R(x))"/>
-  <entry n="8" l="13" r="3" d="0" t="@x(A(x)) &amp; @x(B(x))"/>
-  <entry n="9" l="13" r="4" d="0" t="A(a) $ ((B(b) &amp; C(b)) | (B(b) &amp; D(b)))"/>
+  <entry n="5" l="15" r="1" d="0" t="(A &amp; B) | (A &amp; C)"/>
+  <entry n="6" l="15" r="5" d="0" t="((A &amp; B) | A) &amp; ((A &amp; B) | C)"/>
+  <entry n="7" l="15" r="2" d="0" t="#x(P(x)) | #x(Q(x)) | #x(R(x))"/>
+  <entry n="8" l="15" r="3" d="0" t="@x(A(x)) &amp; @x(B(x))"/>
+  <entry n="9" l="15" r="4" d="0" t="A(a) $ ((B(b) &amp; C(b)) | (B(b) &amp; D(b)))"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-ep.tle
+++ b/doc/proofs/equivalence/pf-ep.tle
@@ -11,8 +11,8 @@
   <entry n="3" t="(K &amp; J &amp; M) $ L  ;; An example of exportation's generalization"/>
  </premises>
  <conclusions>
-  <entry n="4" l="16" r="1" d="0" t="(A &amp; B) $ C"/>
-  <entry n="5" l="16" r="2" d="0" t="X(a) &amp; ((X(y) &amp; Z(a)) $ Z(y))"/>
-  <entry n="6" l="16" r="3" d="0" t="K $ (J $ (M $ L))"/>
+  <entry n="4" l="18" r="1" d="0" t="(A &amp; B) $ C"/>
+  <entry n="5" l="18" r="2" d="0" t="X(a) &amp; ((X(y) &amp; Z(a)) $ Z(y))"/>
+  <entry n="6" l="18" r="3" d="0" t="K $ (J $ (M $ L))"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-eq.tle
+++ b/doc/proofs/equivalence/pf-eq.tle
@@ -9,7 +9,7 @@
   <entry n="2" t="@x(P(x) % Q(x))  ;; A sentence part"/>
  </premises>
  <conclusions>
-  <entry n="3" l="14" r="1" d="0" t="(A $ B) &amp; (B $ A)"/>
-  <entry n="4" l="14" r="2" d="0" t="@x((P(x) $ Q(x)) &amp; (Q(x) $ P(x)))"/>
+  <entry n="3" l="16" r="1" d="0" t="(A $ B) &amp; (B $ A)"/>
+  <entry n="4" l="16" r="2" d="0" t="@x((P(x) $ Q(x)) &amp; (Q(x) $ P(x)))"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-id.tle
+++ b/doc/proofs/equivalence/pf-id.tle
@@ -15,11 +15,11 @@
   <entry n="4" t="@x(R(x) &amp; R(x) &amp; H(x))  ;; And one with quantifiers."/>
  </premises>
  <conclusions>
-  <entry n="5" l="12" r="1" d="0" t="A"/>
-  <entry n="6" l="12" r="2" d="0" t="P(a)"/>
-  <entry n="7" l="12" r="3" d="0" t="P(a) &amp; f(a) : b"/>
-  <entry n="8" l="12" r="4" d="0" t="@x(R(x) &amp; H(x))"/>
-  <entry n="9" l="12" r="6" d="0" t="P(a) | P(a)"/>
-  <entry n="10" l="12" r="8" d="0" t="@x(R(x) &amp; H(x)) | @x(R(x) &amp; H(x))"/>
+  <entry n="5" l="14" r="1" d="0" t="A"/>
+  <entry n="6" l="14" r="2" d="0" t="P(a)"/>
+  <entry n="7" l="14" r="3" d="0" t="P(a) &amp; f(a) : b"/>
+  <entry n="8" l="14" r="4" d="0" t="@x(R(x) &amp; H(x))"/>
+  <entry n="9" l="14" r="6" d="0" t="P(a) | P(a)"/>
+  <entry n="10" l="14" r="8" d="0" t="@x(R(x) &amp; H(x)) | @x(R(x) &amp; H(x))"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-im.tle
+++ b/doc/proofs/equivalence/pf-im.tle
@@ -13,9 +13,9 @@
   <entry n="4" t="~C | D"/>
  </premises>
  <conclusions>
-  <entry n="5" l="8" r="1" d="0" t="~A | B"/>
-  <entry n="6" l="8" r="2" d="0" t="~A | (~B | C)"/>
-  <entry n="7" l="8" r="3" d="0" t="A &amp; (~B | C)"/>
-  <entry n="8" l="8" r="4" d="0" t="C $ D ; And back again"/>
+  <entry n="5" l="10" r="1" d="0" t="~A | B"/>
+  <entry n="6" l="10" r="2" d="0" t="~A | (~B | C)"/>
+  <entry n="7" l="10" r="3" d="0" t="A &amp; (~B | C)"/>
+  <entry n="8" l="10" r="4" d="0" t="C $ D ; And back again"/>
  </conclusions>
 </proof>

--- a/doc/proofs/equivalence/pf-sb.tle
+++ b/doc/proofs/equivalence/pf-sb.tle
@@ -10,8 +10,8 @@
   <entry n="2" t="P(a) &amp; (Q(i) | (Q(i) &amp; A(q)))  ;; Operating on sentence parts."/>
  </premises>
  <conclusions>
-  <entry n="3" l="17" r="1" d="0" t="A"/>
-  <entry n="4" l="17" r="2" d="0" t="P(a) &amp; Q(i)"/>
-  <entry n="5" l="17" r="3" d="0" t="A | (A &amp; C)"/>
+  <entry n="3" l="19" r="1" d="0" t="A"/>
+  <entry n="4" l="19" r="2" d="0" t="P(a) &amp; Q(i)"/>
+  <entry n="5" l="19" r="3" d="0" t="A | (A &amp; C)"/>
  </conclusions>
 </proof>

--- a/doc/proofs/miscellaneous/pf-sp.tle
+++ b/doc/proofs/miscellaneous/pf-sp.tle
@@ -11,6 +11,6 @@
   <entry n="3" l="0" r="" d="1" t="R"/>
   <entry n="4" l="0" r="1,3" d="1" t="A"/>
   <entry n="5" l="0" r="2,4" d="1" t="B"/>
-  <entry n="6" l="28" r="3" d="0" t="R $ B"/>
+  <entry n="6" l="31" r="3" d="0" t="R $ B"/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-bv.tle
+++ b/doc/proofs/quantifier/pf-bv.tle
@@ -8,7 +8,7 @@
   <entry n="2" t="@x@y(P(x,y))"/>
  </premises>
  <conclusions>
-  <entry n="3" l="22" r="1" d="0" t="A(a) &amp; #y(P(y) &amp; Q(y))"/>
-  <entry n="4" l="22" r="2" d="0" t="@x@x(P(x,x))  ;; This is syntactically incorrect."/>
+  <entry n="3" l="25" r="1" d="0" t="A(a) &amp; #y(P(y) &amp; Q(y))"/>
+  <entry n="4" l="25" r="2" d="0" t="@x@x(P(x,x))  ;; This is syntactically incorrect."/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-eg.tle
+++ b/doc/proofs/quantifier/pf-eg.tle
@@ -7,7 +7,7 @@
   <entry n="1" t="P(a) &amp; R(a)"/>
  </premises>
  <conclusions>
-  <entry n="2" l="20" r="1" d="0" t="#x(P(x) &amp; R(x))  ;; That's all there really is to this rule."/>
-  <entry n="3" l="20" r="1" d="0" t="#x(P(x) &amp; R(a))  ;; One need not replace every instance of the variable."/>
+  <entry n="2" l="23" r="1" d="0" t="#x(P(x) &amp; R(x))  ;; That's all there really is to this rule."/>
+  <entry n="3" l="23" r="1" d="0" t="#x(P(x) &amp; R(a))  ;; One need not replace every instance of the variable."/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-ei.tle
+++ b/doc/proofs/quantifier/pf-ei.tle
@@ -9,10 +9,10 @@
   <entry n="2" t="R(w)  ;; Introduces the variable 'w'."/>
  </premises>
  <conclusions>
-  <entry n="3" l="21" r="1" d="0" t="P(a)"/>
+  <entry n="3" l="24" r="1" d="0" t="P(a)"/>
   <entry n="4" l="-1" r="" d="1" t="#x(Z(x))"/>
-  <entry n="5" l="21" r="4" d="1" t="Z(b)"/>
-  <entry n="6" l="21" r="1" d="0" t="P(b)  ;; Since the variable was introduced within a subproof,&#10;&#9;  it it not considred used outside of it."/>
-  <entry n="7" l="21" r="1" d="0" t="P(w)  ;; This won't work, since 'w' was already used in the current scope."/>
+  <entry n="5" l="24" r="4" d="1" t="Z(b)"/>
+  <entry n="6" l="24" r="1" d="0" t="P(b)  ;; Since the variable was introduced within a subproof,&#10;&#9;  it it not considred used outside of it."/>
+  <entry n="7" l="24" r="1" d="0" t="P(w)  ;; This won't work, since 'w' was already used in the current scope."/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-fv.tle
+++ b/doc/proofs/quantifier/pf-fv.tle
@@ -10,7 +10,7 @@
   <entry n="3" t="t = r"/>
  </premises>
  <conclusions>
-  <entry n="4" l="26" r="1,2" d="0" t="J(f)"/>
-  <entry n="5" l="26" r="1,3" d="0" t="f = r"/>
+  <entry n="4" l="29" r="1,2" d="0" t="J(f)"/>
+  <entry n="5" l="29" r="1,3" d="0" t="f = r"/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-ii.tle
+++ b/doc/proofs/quantifier/pf-ii.tle
@@ -9,8 +9,8 @@
   <entry n="1" t=""/>
  </premises>
  <conclusions>
-  <entry n="2" l="25" r="" d="0" t="a = a"/>
-  <entry n="3" l="25" r="" d="0" t="f(c) = f(c)"/>
-  <entry n="4" l="25" r="" d="0" t="a + b = a + b"/>
+  <entry n="2" l="28" r="" d="0" t="a = a"/>
+  <entry n="3" l="28" r="" d="0" t="f(c) = f(c)"/>
+  <entry n="4" l="28" r="" d="0" t="a + b = a + b"/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-nq.tle
+++ b/doc/proofs/quantifier/pf-nq.tle
@@ -14,10 +14,10 @@
   <entry n="4" t="P(a) &amp; @x(Q(s))  ;; On a sentence part."/>
  </premises>
  <conclusions>
-  <entry n="5" l="23" r="1" d="0" t="P(a)"/>
-  <entry n="6" l="23" r="2" d="0" t="(P(a) &amp; P(b)) | (R(m) $ S(m))"/>
-  <entry n="7" l="23" r="3" d="0" t="P"/>
-  <entry n="8" l="23" r="4" d="0" t="P(a) &amp; Q(s)"/>
-  <entry n="9" l="23" r="7" d="0" t="@y(P)"/>
+  <entry n="5" l="26" r="1" d="0" t="P(a)"/>
+  <entry n="6" l="26" r="2" d="0" t="(P(a) &amp; P(b)) | (R(m) $ S(m))"/>
+  <entry n="7" l="26" r="3" d="0" t="P"/>
+  <entry n="8" l="26" r="4" d="0" t="P(a) &amp; Q(s)"/>
+  <entry n="9" l="26" r="7" d="0" t="@y(P)"/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-pr.tle
+++ b/doc/proofs/quantifier/pf-pr.tle
@@ -13,9 +13,9 @@
   <entry n="4" t="#u(I(u) | P(u)) | (O | K)"/>
  </premises>
  <conclusions>
-  <entry n="5" l="24" r="1" d="0" t="@x(P(x) &amp; Q(x)) &amp; (A &amp; B)"/>
-  <entry n="6" l="24" r="2" d="0" t="A(a) &amp; (#z(T(z) &amp; F(z)) &amp; (P &amp; Q))"/>
-  <entry n="7" l="24" r="3" d="0" t="@y(E(y) | L(y) | C | W)"/>
-  <entry n="8" l="24" r="4" d="0" t="#u(I(u) | P(u) | O | K)"/>
+  <entry n="5" l="27" r="1" d="0" t="@x(P(x) &amp; Q(x)) &amp; (A &amp; B)"/>
+  <entry n="6" l="27" r="2" d="0" t="A(a) &amp; (#z(T(z) &amp; F(z)) &amp; (P &amp; Q))"/>
+  <entry n="7" l="27" r="3" d="0" t="@y(E(y) | L(y) | C | W)"/>
+  <entry n="8" l="27" r="4" d="0" t="#u(I(u) | P(u) | O | K)"/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-ug.tle
+++ b/doc/proofs/quantifier/pf-ug.tle
@@ -8,9 +8,9 @@
   <entry n="2" t="P(a)"/>
  </premises>
  <conclusions>
-  <entry n="3" l="19" r="1" d="0" t="U(g) &amp; D(g)"/>
+  <entry n="3" l="22" r="1" d="0" t="U(g) &amp; D(g)"/>
   <entry n="4" l="2" r="3" d="0" t="U(g)"/>
-  <entry n="5" l="18" r="4" d="0" t="@x(U(x))    ;; Since the variable was introduced from a conclusion,&#10;&#9;&#9;it is considered to be arbitrary."/>
-  <entry n="6" l="18" r="2" d="0" t="@x(P(x))  ;;  Since 'a' was introduced in a premise, it is not arbitrary."/>
+  <entry n="5" l="21" r="4" d="0" t="@x(U(x))    ;; Since the variable was introduced from a conclusion,&#10;&#9;&#9;it is considered to be arbitrary."/>
+  <entry n="6" l="21" r="2" d="0" t="@x(P(x))  ;;  Since 'a' was introduced in a premise, it is not arbitrary."/>
  </conclusions>
 </proof>

--- a/doc/proofs/quantifier/pf-ui.tle
+++ b/doc/proofs/quantifier/pf-ui.tle
@@ -10,10 +10,10 @@
   <entry n="2" t="@x(A(x) &amp; @y(B(y)))"/>
  </premises>
  <conclusions>
-  <entry n="3" l="19" r="1" d="0" t="P(a) $ Q(a)"/>
-  <entry n="4" l="19" r="2" d="0" t="A(b) &amp; @y(B(y))"/>
+  <entry n="3" l="22" r="1" d="0" t="P(a) $ Q(a)"/>
+  <entry n="4" l="22" r="2" d="0" t="A(b) &amp; @y(B(y))"/>
   <entry n="5" l="2" r="4" d="0" t="@y(B(y))"/>
-  <entry n="6" l="19" r="5" d="0" t="B(a)"/>
-  <entry n="7" l="19" r="5" d="0" t="B(b)"/>
+  <entry n="6" l="22" r="5" d="0" t="B(a)"/>
+  <entry n="7" l="22" r="5" d="0" t="B(b)"/>
  </conclusions>
 </proof>

--- a/qt/DrawerTools.qml
+++ b/qt/DrawerTools.qml
@@ -110,16 +110,12 @@ ToolBar {
         }
 
         ToolButton {
-            text: qsTr("Export To LaTeX")
+            text: qsTr("Export")
             icon.name: "export"
             icon.color: darkMode ? "white" : "black"
 
             onClicked: {
-                if (Qt.platform.os === "wasm")
-                    auxConnector.wasmLatex(theData, cConnector)
-                else
-                    latexID.open()
-
+                exportFormatID.open()
                 menuOptions.close()
             }
         }

--- a/qt/GoalLine.qml
+++ b/qt/GoalLine.qml
@@ -73,21 +73,49 @@ RowLayout {
 
         // Implementing Keyboard Macros
         onTextChanged: {
+            let replaced = false;
 
             if (goalTextID.length >= 2) {
                 const last_two = text.slice(cursorPosition - 2, cursorPosition)
                 if (last_two.includes('/\\')) {
                     goalTextID.remove(cursorPosition - 2, cursorPosition)
                     goalTextID.insert(cursorPosition, "\u2227")
+                    replaced = true;
                 } else if (last_two.includes('\\/')) {
                     goalTextID.remove(cursorPosition - 2, cursorPosition)
                     goalTextID.insert(cursorPosition, "\u2228")
+                    replaced = true;
                 } else if (last_two.includes('->')) {
                     goalTextID.remove(cursorPosition - 2, cursorPosition)
                     goalTextID.insert(cursorPosition, "\u2192")
+                    replaced = true;
                 } else if (last_two.includes('<' + "\u2192")) {
                     goalTextID.remove(cursorPosition - 2, cursorPosition)
                     goalTextID.insert(cursorPosition, "\u2194")
+                    replaced = true;
+                }
+            }
+
+            if (!replaced && goalTextID.length >= 1) {
+                const last_one = text.slice(cursorPosition - 1, cursorPosition)
+                let replacement = "";
+                switch (last_one) {
+                    case '^': replacement = "\u2295"; break; // XOR
+                    case '&': replacement = "\u2227"; break; // AND
+                    case '|': replacement = "\u2228"; break; // OR
+                    case '~': replacement = "\u00AC"; break; // NOT
+                    case '$': replacement = "\u2192"; break; // CON
+                    case '%': replacement = "\u2194"; break; // BIC
+                    case '@': replacement = "\u2200"; break; // UNV
+                    case '#': replacement = "\u2203"; break; // EXL
+                    case '!': replacement = "\u22A4"; break; // TAU
+                    case '?': replacement = "\u22A5"; break; // CTR
+                    case ':': replacement = "\u2208"; break; // ELM
+                    case '>': replacement = "\u2349"; break; // NIL
+                }
+                if (replacement !== "") {
+                    goalTextID.remove(cursorPosition - 1, cursorPosition)
+                    goalTextID.insert(cursorPosition, replacement)
                 }
             }
         }

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -929,6 +929,7 @@ Item {
 
                 // Implementation for Keyboard Macros
                 onTextChanged: {
+                    let replaced = false;
 
                     // TODO: Improve implementation later
                     if (theTextID.length >= 2) {
@@ -937,15 +938,42 @@ Item {
                         if (last_two.includes('/\\')) {
                             theTextID.remove(cursorPosition - 2, cursorPosition)
                             theTextID.insert(cursorPosition, "\u2227")
+                            replaced = true;
                         } else if (last_two.includes('\\/')) {
                             theTextID.remove(cursorPosition - 2, cursorPosition)
                             theTextID.insert(cursorPosition, "\u2228")
+                            replaced = true;
                         } else if (last_two.includes('->')) {
                             theTextID.remove(cursorPosition - 2, cursorPosition)
                             theTextID.insert(cursorPosition, "\u2192")
+                            replaced = true;
                         } else if (last_two.includes('<' + "\u2192")) {
                             theTextID.remove(cursorPosition - 2, cursorPosition)
                             theTextID.insert(cursorPosition, "\u2194")
+                            replaced = true;
+                        }
+                    }
+
+                    if (!replaced && theTextID.length >= 1) {
+                        const last_one = text.slice(cursorPosition - 1, cursorPosition)
+                        let replacement = "";
+                        switch (last_one) {
+                            case '^': replacement = "\u2295"; break; // XOR
+                            case '&': replacement = "\u2227"; break; // AND
+                            case '|': replacement = "\u2228"; break; // OR
+                            case '~': replacement = "\u00AC"; break; // NOT
+                            case '$': replacement = "\u2192"; break; // CON
+                            case '%': replacement = "\u2194"; break; // BIC
+                            case '@': replacement = "\u2200"; break; // UNV
+                            case '#': replacement = "\u2203"; break; // EXL
+                            case '!': replacement = "\u22A4"; break; // TAU
+                            case '?': replacement = "\u22A5"; break; // CTR
+                            case ':': replacement = "\u2208"; break; // ELM
+                            case '>': replacement = "\u2349"; break; // NIL
+                        }
+                        if (replacement !== "") {
+                            theTextID.remove(cursorPosition - 1, cursorPosition)
+                            theTextID.insert(cursorPosition, replacement)
                         }
                     }
                 }

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -28,6 +28,14 @@ Item {
     property var selectedIndices: []
     property int lastSelectedIndex: -1
 
+    // Public API consumed by main.qml (jump-to-line dialog, Ctrl+J)
+    readonly property int listViewCount: listView.count
+    function jumpToLine(idx) {
+        if (idx < 0 || idx >= listView.count) return
+        listView.currentIndex = idx
+        listView.positionViewAtIndex(idx, ListView.Center)
+    }
+
     // Returns a human-readable string listing every conclusion line whose
     // refs array contains `lineNum` (1-based).  Empty string = no incoming refs.
     function findIncomingRefs(lineNum) {
@@ -36,7 +44,7 @@ Item {
         for (var i = 0; i < n; i++) {
             var refs = proofModel.data(proofModel.index(i, 0), 263)  // RefsRole
             if (refs && Array.from(refs).indexOf(lineNum) !== -1)
-                holders.push(proofModel.data(proofModel.index(i, 0), 256) + 1)  // LineRole (1-based display)
+                holders.push(proofModel.data(proofModel.index(i, 0), 256))  // LineRole is already 1-based
         }
         return holders.length === 0 ? "" : holders.join(", ")
     }
@@ -49,6 +57,12 @@ Item {
         var pSubSt  = proofModel.data(proofModel.index(myIdx, 0), 260)  // SubStartRole
         var pSubEnd = proofModel.data(proofModel.index(myIdx, 0), 261)  // SubEndRole
         var pInd    = proofModel.data(proofModel.index(myIdx, 0), 262)  // IndentRole
+        var pLine   = proofModel.data(proofModel.index(myIdx, 0), 256)  // LineRole (1-based)
+
+        // Scrub all incoming refs to this line from every other row BEFORE
+        // the physical remove+reinsert so no row ends up self-referencing.
+        // Uses C++ directly to avoid QVariant conversion issues from QML.
+        proofModel.clearRefsToLine(pLine)
 
         theData.removeLineAt(myIdx)
         proofModel.updateLines()
@@ -71,7 +85,11 @@ Item {
     // Edge-case conversion: move conclusion at myIdx to the boundary, then convert.
     // Called when the line is NOT the first conclusion (requires a physical move).
     function doConvertConclusion(myIdx) {
-        var cText = proofModel.data(proofModel.index(myIdx, 0), 257)  // TextRole
+        var cText  = proofModel.data(proofModel.index(myIdx, 0), 257)  // TextRole
+        var cLine  = proofModel.data(proofModel.index(myIdx, 0), 256)  // LineRole (1-based)
+
+        // Scrub all incoming refs to this conclusion before moving it.
+        proofModel.clearRefsToLine(cLine)
 
         theData.removeLineAt(myIdx)
         proofModel.updateLines()
@@ -146,6 +164,235 @@ Item {
             }
         }
     }
+
+    // ── Navigation: move focus one line at a time ─────────────────────────
+    // Alt+Up / Alt+Down = Option+Up / Option+Down on macOS.
+    // These are the only bindings for focus movement — Ctrl/Cmd are reserved
+    // for the jump-to-first/last shortcuts below.
+    Shortcut {
+        sequences: ["Alt+Up"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            if (listView.count > 0)
+                listView.currentIndex = Math.max(0, listView.currentIndex - 1)
+        }
+    }
+    Shortcut {
+        sequences: ["Alt+Down"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            if (listView.count > 0)
+                listView.currentIndex = Math.min(listView.count - 1,
+                                                  listView.currentIndex + 1)
+        }
+    }
+
+    // ── Navigation: jump to first / last line ─────────────────────────────
+    // Ctrl+Home  / Ctrl+End  = standard Windows/Linux.
+    // Ctrl+Up    / Ctrl+Down = Cmd+Up / Cmd+Down on macOS (standard macOS
+    //   document navigation: Command+Up jumps to top, Command+Down to bottom).
+    Shortcut {
+        sequences: ["Ctrl+Home", "Ctrl+Up"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            if (listView.count > 0) {
+                listView.currentIndex = 0
+                listView.positionViewAtBeginning()
+            }
+        }
+    }
+    Shortcut {
+        sequences: ["Ctrl+End", "Ctrl+Down"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            if (listView.count > 0) {
+                listView.currentIndex = listView.count - 1
+                listView.positionViewAtEnd()
+            }
+        }
+    }
+
+    // Ctrl+Return / Cmd+Return — add a conclusion line.
+    // If the current line is a premise, inserts at the end of the premise
+    // block (right after the last premise) so the new conclusion is always
+    // in the correct structural position.
+    // If the current line is already a conclusion, inserts immediately below.
+    Shortcut {
+        sequences: ["Ctrl+Return", "Meta+Return"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            var cur = listView.currentIndex
+            if (cur < 0) {
+                cConnector.evalText = "⚠ " + qsTr("No line selected.")
+                return
+            }
+            var curType = proofModel.data(proofModel.index(cur, 0), 258)  // TypeRole
+            var curSub  = proofModel.data(proofModel.index(cur, 0), 259)  // SubRole
+            var curInd  = proofModel.data(proofModel.index(cur, 0), 262)  // IndentRole
+
+            // If on a premise line, always insert right after the last premise
+            // so the new line lands cleanly in the conclusion block.
+            var insertAt = (curType === "premise")
+                           ? proofModel.premiseCount
+                           : cur + 1
+
+            theData.insertLine(insertAt, insertAt + 1, "", "choose",
+                               curSub, false, false, curInd, [-1])
+            proofModel.updateLines()
+            proofModel.updateRefs(insertAt, true)
+            listView.currentIndex = insertAt
+            fileModified = true
+            cConnector.evalText = "Evaluate Proof"
+            proofModel.clearErrors()
+        }
+    }
+
+    // Ctrl+Shift+Return — add a premise line.
+    // Inserted at the current position when inside the premise block, or at
+    // the end of the premise block when the cursor is in the conclusions.
+    // NOTE: setPremiseCount() is private; premiseCount is recomputed
+    //       automatically by the postLineInsert signal connection.
+    Shortcut {
+        sequences: ["Ctrl+Shift+Return", "Meta+Shift+Return"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            var cur = listView.currentIndex
+            if (cur < 0) {
+                cConnector.evalText = "⚠ " + qsTr("No line selected.")
+                return
+            }
+            var insertIndex = (cur < proofModel.premiseCount)
+                              ? cur + 1 : proofModel.premiseCount
+            theData.insertLine(insertIndex, insertIndex + 1, "", "premise",
+                               false, false, false, 0, [-1])
+            proofModel.updateLines()
+            proofModel.updateRefs(insertIndex, true)
+            listView.currentIndex = insertIndex
+            // premiseCount is recomputed automatically via postLineInsert signal.
+            fileModified = true
+            cConnector.evalText = "Evaluate Proof"
+            proofModel.clearErrors()
+        }
+    }
+
+    // Ctrl+Delete / Cmd+Delete / Cmd+Backspace — remove the currently focused line.
+    // Cmd+Backspace covers compact Mac keyboards that lack a physical Delete key.
+    // If it is the very last line, resets to a blank premise so the UI never
+    // shows an empty proof.
+    // NOTE: setPremiseCount() is private; premiseCount is recomputed
+    //       automatically by the postLineRemove signal connection.
+    Shortcut {
+        sequences: ["Ctrl+Delete", "Meta+Delete", "Ctrl+Backspace"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            var cur = listView.currentIndex
+            if (cur < 0) {
+                cConnector.evalText = "⚠ " + qsTr("No line selected.")
+                return
+            }
+
+            if (listView.count > 1) {
+                theData.removeLineAt(cur)
+                proofModel.updateLines()
+                proofModel.updateRefs(cur, false)
+                listView.currentIndex = Math.min(cur, listView.count - 1)
+            } else {
+                // Last remaining line — reset to a blank premise.
+                theData.removeLineAt(0)
+                theData.insertLine(0, 1, "", "premise", false, false, false, 0, [-1])
+                proofModel.updateLines()
+                listView.currentIndex = 0
+            }
+            // premiseCount is recomputed automatically via postLineRemove signal.
+            fileModified = true
+            cConnector.evalText = "Evaluate Proof"
+            proofModel.clearErrors()
+        }
+    }
+
+    // Ctrl+Shift+X / Cmd+Shift+X — toggle the current line between premise and conclusion.
+    // (X represents eXchange. This avoids Chrome's Ctrl+T, OS-level Cmd+T, and 
+    // Wasm Ctrl+Alt/AltGraph dead-key issues).
+    //
+    // Rules (mirrors the +/– menu "Convert" action):
+    //   • Subproof / sf lines are ignored.
+    //   • The last remaining premise cannot be converted away.
+    //   • Boundary lines (no physical move needed) call toggleLineType() directly.
+    //   • Non-boundary lines call doConvertPremise / doConvertConclusion,
+    //     which physically move the row to the block boundary first.
+    //   • If a premise is referenced by other lines the warning dialog is shown.
+    Shortcut {
+        sequences: ["Ctrl+Shift+X", "Meta+Shift+X"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            var cur = listView.currentIndex
+            if (cur < 0) {
+                cConnector.evalText = "⚠ " + qsTr("No line selected.")
+                return
+            }
+
+            var curType = proofModel.data(proofModel.index(cur, 0), 258)  // TypeRole
+            var curLine = proofModel.data(proofModel.index(cur, 0), 256)  // LineRole (1-based)
+
+            // Refuse structural subproof / sf lines
+            if (curType === "sf" || curType === "subproof") {
+                cConnector.evalText = "⚠ " + qsTr("Cannot convert structural subproof lines.")
+                return
+            }
+
+            if (curType === "premise") {
+                // Must keep at least one premise
+                if (proofModel.premiseCount <= 1) {
+                    cConnector.evalText = "⚠ " + qsTr("Proof must contain at least one premise.")
+                    return
+                }
+
+                var refHolders = rootProofArea.findIncomingRefs(curLine)
+
+                if (cur === proofModel.premiseCount - 1) {
+                    // Boundary — no physical move needed; atomic toggle.
+                    if (refHolders !== "") {
+                        // Referenced lines — show confirmation dialog.
+                        convertWarningID.pendingIdx  = cur
+                        convertWarningID.pendingType = curType
+                        convertWarningID.refHolders  = refHolders
+                        convertWarningID.open()
+                    } else {
+                        proofModel.toggleLineType(cur)
+                        fileModified = true
+                        cConnector.evalText = "Evaluate Proof"
+                        proofModel.clearErrors()
+                    }
+                } else {
+                    // Non-boundary — physical move to block boundary required.
+                    if (refHolders !== "") {
+                        convertWarningID.pendingIdx  = cur
+                        convertWarningID.pendingType = curType
+                        convertWarningID.refHolders  = refHolders
+                        convertWarningID.open()
+                    } else {
+                        rootProofArea.doConvertPremise(cur)
+                    }
+                }
+            } else {
+                // conclusion → premise
+                if (cur === proofModel.premiseCount) {
+                    // Boundary — atomic toggle.
+                    proofModel.toggleLineType(cur)
+                    fileModified = true
+                    cConnector.evalText = "Evaluate Proof"
+                    proofModel.clearErrors()
+                } else {
+                    // Non-boundary — physical move to block boundary required.
+                    rootProofArea.doConvertConclusion(cur)
+                }
+            }
+        }
+    }
+
+
+
+    // End shortcuts
 
     // Right-click context menu (shared, one instance) 
 
@@ -401,8 +648,8 @@ Item {
             ScrollBar.vertical: ScrollBar {}
 
             onCurrentItemChanged: {
-                if (currentItem)
-                    currentItem.children[1].forceActiveFocus()
+                if (currentItem && currentItem.focusTextField)
+                    currentItem.focusTextField()
             }
         }
     }
@@ -443,6 +690,12 @@ Item {
                 var temp = listView.currentIndex
                 listView.currentIndex = -1
                 listView.currentIndex = temp
+            }
+
+            // Called by ListView.onCurrentItemChanged to focus this delegate's
+            // text field reliably without fragile children[] index traversal.
+            function focusTextField() {
+                theTextID.forceActiveFocus()
             }
 
             // Restore stored integer role values when language change resets combobox models.
@@ -555,6 +808,27 @@ Item {
                         rootProofArea.lastSelectedIndex = listView.count > 0 ? listView.count - 1 : -1
                         rootProofArea.forceActiveFocus()
                         event.accepted = true
+                    }
+                }
+
+                // Up arrow at cursor position 0 → move focus to the line above.
+                // Down arrow at end of text → move focus to the line below.
+                // This makes plain arrow keys navigate between lines naturally
+                // when there is no more text cursor movement possible.
+                Keys.onUpPressed: (event) => {
+                    if (cursorPosition === 0 && listView.currentIndex > 0) {
+                        listView.currentIndex--
+                        event.accepted = true
+                    } else {
+                        event.accepted = false
+                    }
+                }
+                Keys.onDownPressed: (event) => {
+                    if (cursorPosition === text.length && listView.currentIndex < listView.count - 1) {
+                        listView.currentIndex++
+                        event.accepted = true
+                    } else {
+                        event.accepted = false
                     }
                 }
 

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -662,6 +662,13 @@ Item {
             width: parent ? parent.width : 0
             spacing: 0
 
+            // When this row is inside a collapsed subproof, hide it AND zero
+            // its height so the ListView allocates no space for it (visible:false
+            // alone still reserves height, leaving blank gaps).
+            visible: !model.hidden
+            height:  visible ? implicitHeight : 0
+            clip:    true
+
             // Properties here so ALL descendants (RowLayout + Text) can access by bare name
             property bool editCombos: (!isExtFile || type === "choose")
             property var arr: model.refs
@@ -674,6 +681,10 @@ Item {
             // `model` refers to the combo's own string-array model, NOT the row data.
             property int savedRuleCategory: model.ruleCategory
             property int savedRuleIndex:    model.ruleIndex
+            // Indentation helpers — used by the spacer and chevron inside RowLayout.
+            // U = one indent unit (scaledSpacing*2, zoom-aware). depth = nesting level.
+            readonly property real indentUnit: scaledSpacing * 2
+            readonly property int  depthLevel: model.ind / 20
             property string textFieldColor: {
                 if (rootProofArea.selectedIndices.includes(indexx)) {
                     return darkMode ? "#5C469C" : "#E6E6FA"
@@ -715,6 +726,55 @@ Item {
                 spacing: scaledSpacing
                 width: parent.width
                 Layout.fillWidth: true
+
+                // ── Indentation ─────────────────────────────────────────────
+                // Indent unit U = scaledSpacing*2 per nesting level (zoom-aware).
+                // depth = model.ind / 20.
+                //
+                // sf rows:      spacer = (depth-1)*U + chevron(U) → depth*U total
+                // content rows: spacer =  depth*U                 → depth*U total
+                //
+                // All line numbers at the same depth land at the same x position.
+                Item {
+                    width:  Math.round((outerColumn.depthLevel - (model.subSt ? 1 : 0))
+                                       * outerColumn.indentUnit)
+                    height: 1
+                }
+
+                // Collapse chevron — only on sf rows; always exactly one indentUnit wide.
+                // ▶ = collapsed, ▼ = expanded.
+                Button {
+                    id: collapseToggleID
+                    visible: model.subSt === true
+                    width:   visible ? Math.round(outerColumn.indentUnit) : 0
+                    height:  theTextID.height
+
+                    // Always-visible background — subtle rounded rect, not flat.
+                    background: Rectangle {
+                        radius: 4
+                        color: collapseToggleID.pressed
+                               ? (darkMode ? "#3A3040" : "#C8C8D0")
+                               : (darkMode ? "#2A2530" : "#E0E0E8")
+                    }
+
+                    // Use a Text item so we can set color explicitly (button text
+                    // color can blend into the background depending on the theme).
+                    contentItem: Text {
+                        text:              model.collapsed ? "\u25B6" : "\u25BC"
+                        font.pointSize:    Math.max(8, scaledFontSize * 0.7)
+                        font.bold:         false
+                        color:             darkMode ? "#B0A8C0" : "#505060"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment:   Text.AlignVCenter
+                    }
+
+                    hoverEnabled: true
+                    ToolTip.visible: hovered
+                    ToolTip.delay: 600
+                    ToolTip.text: model.collapsed ? qsTr("Expand subproof") : qsTr("Collapse subproof")
+                    onClicked: proofModel.toggleCollapsed(indexx)
+                }
+
 
             // Line Number Button
             Button {
@@ -795,7 +855,6 @@ Item {
                 color: darkMode ? "white" : "black"
                 height: scaledFontSize + scaledSpacing
                 font.pointSize: scaledFontSize
-                Layout.leftMargin: model.ind
                 Layout.fillWidth: true
 
                 Keys.onPressed: (event) => {

--- a/qt/auxconnector.cpp
+++ b/qt/auxconnector.cpp
@@ -401,3 +401,212 @@ void auxConnector::newWindow()
     delete myProcess;
 }
 #endif
+
+// Plain-text export helper
+
+/* Builds a plain-text representation of one ProofLine.
+ *  depth   = pInd / 20 (0 = top-level, 1 = one subproof deep, …)
+ *  prefix  = box-drawing hint: "┌─" for sf rows, "└─" for the last row
+ *            before a subproof end, "" for everything else.
+ *  Returns a single formatted line with trailing newline.
+ */
+static QString proofLineToText(const ProofLine &pl, int depth, const QString &prefix)
+{
+    // Skip the closing subproof sentinel row — the └─ line already closes it.
+    if (pl.pSubEnd)
+        return QString();
+
+    // Indent: 2 spaces per depth level, then the box-drawing prefix.
+    QString indent = QString("  ").repeated(depth);
+    if (!prefix.isEmpty())
+        indent += prefix + " ";
+    else if (depth > 0)
+        indent += "  ";          // align content rows with the box interior
+
+    // Line number, right-aligned in a 3-char field.
+    QString lineNum = QString::number(pl.pLine).rightJustified(3);
+
+    // Build refs string: "1, 2, 3" (skip sentinel -1).
+    QStringList refStrs;
+    for (int r : pl.pRefs)
+        if (r != -1) refStrs << QString::number(r);
+    QString refs = refStrs.join(", ");
+
+    // Rule / type label (omit for sf rows — the box-drawing says enough).
+    QString rule;
+    if (pl.pSubStart)
+        rule = "(subproof start)";
+    else if (!pl.pType.isEmpty() && pl.pType != "choose")
+        rule = pl.pType + (refs.isEmpty() ? "" : ": " + refs);
+
+    // Compose: "  ┌─  3.  P → Q          [→ Elim: 1, 2]"
+    QString formula = pl.pText.isEmpty() ? "(empty)" : pl.pText;
+    QString left    = indent + lineNum + ".  " + formula;
+    QString ruleTag = rule.isEmpty() ? "" : "  [" + rule + "]";
+
+    // Pad the formula area to a fixed column so rule tags align.
+    const int targetCol = 60;
+    if (left.length() < targetCol)
+        left = left.leftJustified(targetCol);
+
+    return left + ruleTag + "\n";
+}
+
+/* Exports the proof to a plain-text file.
+ *  Reads directly from ProofData — no C engine call needed.
+ *  input:
+ *    name - absolute file path (may have "file://" prefix).
+ *    pd   - pointer to the ProofData object.
+ *  output:
+ *    none (emits errorOccurred on failure).
+ */
+void auxConnector::exportText(const QString &name, const ProofData *pd)
+{
+    QString path = name.startsWith("file://") ? name.mid(7) : name;
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        emit errorOccurred(tr("Text export failed: could not open '%1' for writing.").arg(path));
+        return;
+    }
+
+    QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
+
+    const QVector<ProofLine> &lines = pd->lines();
+    const int n = lines.size();
+
+    // Pre-compute which rows are "last before a subproof end" so we can
+    // add the └─ prefix to them.
+    QSet<int> closingRows;
+    for (int i = 1; i < n; ++i)
+        if (lines.at(i).pSubEnd)
+            closingRows.insert(i - 1);
+
+    out << "Proof\n" << QString("=").repeated(72) << "\n\n";
+
+    for (int i = 0; i < n; ++i) {
+        const ProofLine &pl = lines.at(i);
+        int depth = pl.pInd / 20;
+
+        QString prefix;
+        if (pl.pSubStart)
+            prefix = "\u250c\u2500";                   // ┌─
+        else if (closingRows.contains(i))
+            prefix = "\u2514\u2500";                   // └─
+
+        QString row = proofLineToText(pl, depth, prefix);
+        if (!row.isEmpty())
+            out << row;
+    }
+
+    out << "\n" << QString("=").repeated(72) << "\n";
+    file.close();
+    qDebug() << "[ARIS] exportText: wrote" << path;
+}
+
+/* Exports the proof to a plain-text file (WebAssembly).
+ *  Writes to a temp file then triggers browser download.
+ */
+void auxConnector::wasmExportText(const ProofData *pd)
+{
+    exportText("aris_export_tmp.txt", pd);
+    QFile file("aris_export_tmp.txt");
+    if (file.open(QIODevice::ReadOnly)) {
+        QFileDialog::saveFileContent(file.readAll(), "proof.txt");
+        file.close();
+    }
+    QFile::remove("aris_export_tmp.txt");
+}
+
+//  Markdown export helper
+
+/* Exports the proof to a Markdown file (.md).
+ *  Produces a GitHub-renderable table where the Formula column is
+ *  padded with non-breaking spaces (&#160;) for nesting depth.
+ *  Subproof start/end rows become visual separator rows in the table.
+ *  input:
+ *    name - absolute file path.
+ *    pd   - pointer to the ProofData object.
+ *  output:
+ *    none (emits errorOccurred on failure).
+ */
+void auxConnector::exportMarkdown(const QString &name, const ProofData *pd)
+{
+    QString path = name.startsWith("file://") ? name.mid(7) : name;
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        emit errorOccurred(tr("Markdown export failed: could not open '%1' for writing.").arg(path));
+        return;
+    }
+
+    QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
+
+    const QVector<ProofLine> &lines = pd->lines();
+    const int n = lines.size();
+
+    out << "# Proof\n\n";
+    out << "| # | Formula | Rule | Refs |\n";
+    out << "|---|---------|------|------|\n";
+
+    for (int i = 0; i < n; ++i) {
+        const ProofLine &pl = lines.at(i);
+        int depth = pl.pInd / 20;
+
+        // Non-breaking space indent (4 per level) for the formula column.
+        QString nbsp  = QString("&nbsp;").repeated(depth * 4);
+
+        if (pl.pSubStart) {
+            // Subproof opening row — show as a light separator with label.
+            out << "| | " << nbsp << "*subproof start* | | |\n";
+            continue;
+        }
+        if (pl.pSubEnd) {
+            // Subproof closing row — show as a light separator.
+            out << "| | " << nbsp << "*subproof end* | | |\n";
+            continue;
+        }
+
+        // Regular line.
+        QString lineNum = QString::number(pl.pLine);
+        QString formula = pl.pText.isEmpty() ? "*(empty)*" : pl.pText;
+
+        // Rule label (blank for premises displayed as "premise").
+        QString rule = (pl.pType == "premise") ? "premise" : pl.pType;
+        if (rule == "choose") rule = "";
+
+        // Refs: "1, 2" (skip -1 sentinel).
+        QStringList refStrs;
+        for (int r : pl.pRefs)
+            if (r != -1) refStrs << QString::number(r);
+        QString refs = refStrs.join(", ");
+
+        // Escape pipe characters in formula so the table doesn't break.
+        formula.replace("|", "\\|");
+        rule.replace("|", "\\|");
+
+        out << "| " << lineNum
+            << " | " << nbsp << formula
+            << " | " << rule
+            << " | " << refs
+            << " |\n";
+    }
+
+    out << "\n*Generated by GNU Aris*\n";
+    file.close();
+    qDebug() << "[ARIS] exportMarkdown: wrote" << path;
+}
+
+/* Exports the proof to a Markdown file (WebAssembly).
+ *  Writes to a temp file then triggers browser download.
+ */
+void auxConnector::wasmExportMarkdown(const ProofData *pd)
+{
+    exportMarkdown("aris_export_tmp.md", pd);
+    QFile file("aris_export_tmp.md");
+    if (file.open(QIODevice::ReadOnly)) {
+        QFileDialog::saveFileContent(file.readAll(), "proof.md");
+        file.close();
+    }
+    QFile::remove("aris_export_tmp.md");
+}

--- a/qt/auxconnector.h
+++ b/qt/auxconnector.h
@@ -30,6 +30,15 @@ public:
 
     Q_INVOKABLE void latex(const QString &name, const ProofData *toBeEval , Connector *c);
     Q_INVOKABLE void wasmLatex(const ProofData *pd, Connector *c);
+
+    // Plain-text export (desktop + WASM)
+    Q_INVOKABLE void exportText(const QString &name, const ProofData *pd);
+    Q_INVOKABLE void wasmExportText(const ProofData *pd);
+
+    // Markdown export (desktop + WASM)
+    Q_INVOKABLE void exportMarkdown(const QString &name, const ProofData *pd);
+    Q_INVOKABLE void wasmExportMarkdown(const ProofData *pd);
+
     Q_INVOKABLE void importProof(const QString &name, ProofData *pd, const Connector *c, ProofModel *pm);
     Q_INVOKABLE void wasmImportProof(ProofData *pd, const Connector *c, ProofModel *pm);
     Q_INVOKABLE void importProofWithMode(const QString &name, ProofData *pd, const Connector *c, ProofModel *pm, int mode);

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -714,6 +714,146 @@ ApplicationWindow {
         }
     }
 
+    //  Global workflow shortcuts
+    
+    //  Ctrl+Shift+E (Cmd+Shift+E on macOS) — Evaluate proof.
+    Shortcut {
+        sequence: "Ctrl+Shift+E" // Cmd+Shift+E on macOS — avoids Emacs "end-of-line" conflict
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            cConnector.evalText = "Evaluate Proof"
+            cConnector.evalProof(theData, theGoals, proofModel)
+            goalDataID.evalGoals(theGoals, cConnector)
+        }
+    }
+
+    // Ctrl+G — Open the Goals dialog.
+    Shortcut {
+        sequence: "Ctrl+G" //cmd + G for mac os
+        context: Qt.ApplicationShortcut
+        onActivated: goalDialogID.open()
+    }
+
+    // Ctrl+J — Open the jump-to-line dialog.
+    Shortcut {
+        sequence: "Ctrl+J" //cmd+j for mac os
+        context: Qt.ApplicationShortcut
+        onActivated: jumpDialogID.open()
+    }
+
+    // Jump-to-line dialog — opened by Ctrl+J.
+    Dialog {
+        id: jumpDialogID
+
+        title: qsTr("Jump to Line")
+        width: Math.min(rootID.width * 0.30, 300)
+        anchors.centerIn: parent
+
+        parent: Overlay.overlay
+        modal: true
+        closePolicy: Popup.CloseOnEscape
+        padding: 20
+
+        function attemptJump() {
+            var lineNum = parseInt(jumpLineInputID.text, 10)
+            if (isNaN(lineNum) || lineNum < 1 || lineNum > proofID.listViewCount) {
+                jumpErrorMsgID.text = qsTr("Invalid line number. Must be between 1 and ") + proofID.listViewCount
+                jumpErrorMsgID.visible = true
+            } else {
+                jumpErrorMsgID.visible = false
+                proofID.jumpToLine(lineNum - 1)
+                jumpDialogID.close()
+                jumpLineInputID.text = ""
+            }
+        }
+
+        Overlay.modal: Rectangle {
+            color: darkMode ? "#66121212" : "#66CFCFCF"
+        }
+
+        background: Rectangle {
+            radius: 12
+            color: darkMode ? "#1F1B24" : "white"
+            border.width: 1
+            border.color: darkMode ? "#50485A" : "#D9D9D9"
+        }
+
+        contentItem: ColumnLayout {
+            width: jumpDialogID.availableWidth
+            spacing: 16
+
+            Label {
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Line number")
+                color: darkMode ? "white" : "black"
+                font.bold: true
+            }
+
+            TextField {
+                id: jumpLineInputID
+                Layout.fillWidth: true
+                placeholderText: "1 – " + proofID.listViewCount
+                inputMethodHints: Qt.ImhDigitsOnly
+                validator: IntValidator { bottom: 1; top: 9999 }
+                color: darkMode ? "white" : "black"
+                background: Rectangle {
+                    border.width: 1
+                    border.color: darkMode ? "#BB86FC" : "#6200EE"
+                    radius: 6
+                    color: darkMode ? "#2A2631" : "white"
+                }
+                Keys.onReturnPressed: jumpDialogID.attemptJump()
+                onTextChanged: jumpErrorMsgID.visible = false
+                Component.onCompleted: {
+                    if (jumpDialogID.visible) forceActiveFocus()
+                }
+            }
+
+            Label {
+                id: jumpErrorMsgID
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                color: darkMode ? "#CF6679" : "red"
+                font.pointSize: Math.max(10, thefont.pointSize - 1)
+                visible: false
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 12
+
+                Button {
+                    text: qsTr("Cancel")
+                    Layout.fillWidth: true
+                    palette {
+                        button: darkMode ? "#2A2631" : "white"
+                        buttonText: darkMode ? "white" : "black"
+                    }
+                    onClicked: jumpDialogID.close()
+                }
+
+                Button {
+                    text: qsTr("Jump")
+                    Layout.fillWidth: true
+                    palette {
+                        button: darkMode ? "#BB86FC" : "#6200EE"
+                        buttonText: "white"
+                    }
+                    onClicked: jumpDialogID.attemptJump()
+                }
+            }
+        }
+
+        onOpened: {
+            jumpLineInputID.text = ""
+            jumpErrorMsgID.visible = false
+            jumpLineInputID.forceActiveFocus()
+        }
+    }
+
+    // End global shortcuts 
+
     ProofArea {
         id: proofID
     }

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -431,6 +431,26 @@ ApplicationWindow {
     }
 
     FileDialog {
+        id: exportTextID
+
+        nameFilters: ["Text files (*.txt)"]
+        title: "Export as Text"
+        fileMode: FileDialog.SaveFile
+        defaultSuffix: "txt"
+        onAccepted: auxConnector.exportText(selectedFile, theData)
+    }
+
+    FileDialog {
+        id: exportMarkdownID
+
+        nameFilters: ["Markdown files (*.md)"]
+        title: "Export as Markdown"
+        fileMode: FileDialog.SaveFile
+        defaultSuffix: "md"
+        onAccepted: auxConnector.exportMarkdown(selectedFile, theData)
+    }
+
+    FileDialog {
         id: importID
 
         nameFilters: ["Aris files (*.tle)"]
@@ -675,6 +695,96 @@ ApplicationWindow {
                     }
 
                     onClicked: startImportFlow(2)
+                }
+            }
+        }
+    }
+
+    // Export format picker — same style as importBehaviorID.
+    Dialog {
+        id: exportFormatID
+
+        width: Math.min(rootID.width * 0.42, 440)
+        anchors.centerIn: parent
+
+        parent: Overlay.overlay
+        modal: true
+        closePolicy: Popup.CloseOnEscape
+        padding: 20
+
+        Overlay.modal: Rectangle {
+            color: darkMode ? "#66121212" : "#66CFCFCF"
+        }
+
+        background: Rectangle {
+            radius: 12
+            color: darkMode ? "#1F1B24" : "white"
+            border.width: 1
+            border.color: darkMode ? "#50485A" : "#D9D9D9"
+        }
+
+        contentItem: ColumnLayout {
+            width: exportFormatID.availableWidth
+            spacing: 20
+
+            Label {
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                text: qsTr("Choose export format")
+                color: darkMode ? "white" : "black"
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 14
+
+                Button {
+                    text: qsTr("LaTeX")
+                    Layout.fillWidth: true
+                    palette {
+                        button: darkMode ? "#2A2631" : "white"
+                        buttonText: darkMode ? "white" : "black"
+                    }
+                    onClicked: {
+                        exportFormatID.close()
+                        if (Qt.platform.os === "wasm")
+                            auxConnector.wasmLatex(theData, cConnector)
+                        else
+                            latexID.open()
+                    }
+                }
+
+                Button {
+                    text: qsTr("Plain Text")
+                    Layout.fillWidth: true
+                    palette {
+                        button: darkMode ? "#2A2631" : "white"
+                        buttonText: darkMode ? "white" : "black"
+                    }
+                    onClicked: {
+                        exportFormatID.close()
+                        if (Qt.platform.os === "wasm")
+                            auxConnector.wasmExportText(theData)
+                        else
+                            exportTextID.open()
+                    }
+                }
+
+                Button {
+                    text: qsTr("Markdown")
+                    Layout.fillWidth: true
+                    palette {
+                        button: darkMode ? "#2A2631" : "white"
+                        buttonText: darkMode ? "white" : "black"
+                    }
+                    onClicked: {
+                        exportFormatID.close()
+                        if (Qt.platform.os === "wasm")
+                            auxConnector.wasmExportMarkdown(theData)
+                        else
+                            exportMarkdownID.open()
+                    }
                 }
             }
         }

--- a/qt/proofdata.cpp
+++ b/qt/proofdata.cpp
@@ -41,7 +41,8 @@ bool ProofData::setLineAt(int index, const ProofLine &proofLine)
         && oldLine.pType == proofLine.pType && oldLine.pRefs == proofLine.pRefs \
         && oldLine.pErrorMsg == proofLine.pErrorMsg \
         && oldLine.pRuleCategory == proofLine.pRuleCategory \
-        && oldLine.pRuleIndex == proofLine.pRuleIndex)
+        && oldLine.pRuleIndex == proofLine.pRuleIndex \
+        && oldLine.pCollapsed == proofLine.pCollapsed)
     {
         return false;
     }
@@ -104,4 +105,13 @@ void ProofData::setErrorAt(int index, const QString &msg)
     if (index < 0 || index >= m_proofLines.size())
         return;
     m_proofLines[index].pErrorMsg = msg;
+}
+
+// Set the collapsed state for a subproof-start row at the given 0-based index.
+// Bypasses setLineAt so it can never be silently dropped by the equality check.
+void ProofData::setCollapsedAt(int index, bool collapsed)
+{
+    if (index < 0 || index >= m_proofLines.size())
+        return;
+    m_proofLines[index].pCollapsed = collapsed;
 }

--- a/qt/proofdata.h
+++ b/qt/proofdata.h
@@ -38,6 +38,7 @@ struct ProofLine{
     // pRuleIndex   : index within combo2[pRuleCategory].
     int pRuleCategory = -1;
     int pRuleIndex    = -1;
+    bool pCollapsed   = false;  // session-only: true when this sf row is collapsed
 };
 
 class ProofData : public QObject
@@ -62,6 +63,7 @@ public slots:
     void insertLine(int index, int a, QString b, QString c, bool d, bool e, bool f, int g, QList<int> h, int cat = -1, int idx = -1);
     void removeLineAt(int index);
     void setErrorAt(int index, const QString &msg);   // set inline error for a line
+    void setCollapsedAt(int index, bool collapsed);   // toggle subproof collapse state
     Q_INVOKABLE void reset();
 
 private:

--- a/qt/proofmodel.cpp
+++ b/qt/proofmodel.cpp
@@ -314,6 +314,31 @@ void ProofModel::clearErrors()
     }
 }
 
+// Scrub every reference to lineNum (1-based display number) from ALL rows.
+// Called before physically moving a line so no other line ends up with a
+// stale ref that becomes a self-reference after the remove+reinsert cycle.
+// updateRefs(ln, false) only iterates rows AFTER ln — this covers all rows.
+void ProofModel::clearRefsToLine(int lineNum)
+{
+    if (!mLines) return;
+    const int n = mLines->lines().size();
+    for (int i = 0; i < n; i++) {
+        ProofLine ln = mLines->lines().at(i);
+        bool changed = false;
+        // pRefs[0] is always the sentinel -1; start at index 1.
+        for (int j = ln.pRefs.size() - 1; j >= 1; j--) {
+            if (ln.pRefs[j] == lineNum) {
+                ln.pRefs.removeAt(j);
+                changed = true;
+            }
+        }
+        if (changed) {
+            mLines->setLineAt(i, ln);
+            emit dataChanged(index(i, 0), index(i, 0), {RefsRole});
+        }
+    }
+}
+
 // premiseCount property 
 
 int ProofModel::premiseCount() const

--- a/qt/proofmodel.cpp
+++ b/qt/proofmodel.cpp
@@ -114,6 +114,10 @@ QVariant ProofModel::data(const QModelIndex &index, int role) const
         return QVariant(someLine.pRuleCategory);
     case RuleIndexRole:
         return QVariant(someLine.pRuleIndex);
+    case CollapsedRole:
+        return QVariant(someLine.pCollapsed);
+    case HiddenRole:
+        return QVariant(isHiddenByCollapse(index.row()));
     }
     return QVariant();
 }
@@ -189,6 +193,12 @@ bool ProofModel::setData(const QModelIndex &index, const QVariant &value, int ro
             if (!name.isEmpty()) someLine.pType = name;
         }
         break;
+    case CollapsedRole:
+        // Handled by toggleCollapsed() — direct writes are a no-op.
+        return false;
+    case HiddenRole:
+        // Read-only computed role.
+        return false;
     }
 
     if (mLines->setLineAt(index.row(),someLine)) {
@@ -225,6 +235,8 @@ QHash<int, QByteArray> ProofModel::roleNames() const
     names[ErrorRole] = "errMsg";
     names[RuleCategoryRole] = "ruleCategory";
     names[RuleIndexRole]    = "ruleIndex";
+    names[CollapsedRole]    = "collapsed";
+    names[HiddenRole]       = "hidden";
     return names;
 }
 
@@ -403,4 +415,80 @@ void ProofModel::recomputePremiseCount()
             break;
     }
     setPremiseCount(count);
+}
+
+// Returns true if `row` is inside a currently collapsed subproof block.
+//
+// Subproof structure (indent units = 20px each level):
+//   parent scope at indent X
+//     sf row (pSubStart=true)  at indent X+20   ← same as content rows
+//     content rows             at indent X+20
+//     end row (pSubEnd=true)   at indent X
+//
+// Because the sf row sits at the SAME indent as the content rows, we walk
+// backward skipping only rows that are DEEPER (pInd > myInd), then check
+// the first pSubStart row at the same indent — if collapsed, we are hidden.
+bool ProofModel::isHiddenByCollapse(int row) const
+{
+    if (!mLines || row <= 0) return false;
+    const QVector<ProofLine> ls = mLines->lines();
+    const int myInd = ls.at(row).pInd;
+
+    // Rows at indent 0 can never be inside a subproof.
+    if (myInd <= 0) return false;
+
+    for (int i = row - 1; i >= 0; --i) {
+        const ProofLine &pl = ls.at(i);
+
+        // Skip rows that are deeper — they are inside a nested subproof
+        // and cannot be the opener for the current row.
+        if (pl.pInd > myInd) continue;
+
+        // A subproof-start at the same indent level is the direct opener.
+        // If it is collapsed → this row is hidden; if expanded → visible.
+        if (pl.pSubStart && pl.pInd == myInd)
+            return pl.pCollapsed;
+
+        // Hit a row at a strictly lower indent without finding an sf opener
+        // → we are not inside any subproof at this level.
+        if (pl.pInd < myInd)
+            return false;
+
+        // Same-indent non-sf row — keep walking backward.
+    }
+    return false;
+}
+
+// Toggle the pCollapsed flag on a subproof-start (sf) row and notify QML.
+// Emits CollapsedRole on the sf row (updates the chevron ▶/▼) and
+// HiddenRole on every row inside the block so their height/visible update.
+void ProofModel::toggleCollapsed(int row)
+{
+    if (!mLines || row < 0 || row >= mLines->lines().size()) return;
+
+    const QVector<ProofLine> ls = mLines->lines();
+    const ProofLine &sf = ls.at(row);
+
+    // Only act on subproof-start rows.
+    if (!sf.pSubStart) return;
+
+    const bool newVal = !sf.pCollapsed;
+    mLines->setCollapsedAt(row, newVal);
+
+    // Find the matching subproof-end.
+    // The sf row is at indent sfInd; its matching end row is at sfInd - 20.
+    const int totalRows = mLines->lines().size();
+    const int sfInd     = sf.pInd;
+    int endRow = row;
+    for (int i = row + 1; i < totalRows; ++i) {
+        const ProofLine &pl = mLines->lines().at(i);
+        endRow = i;
+        if (pl.pSubEnd && pl.pInd == (sfInd - 20))
+            break;
+    }
+
+    // Notify QML: chevron on the sf row, hidden state on every inner row.
+    emit dataChanged(index(row, 0), index(row, 0), {CollapsedRole});
+    if (endRow > row)
+        emit dataChanged(index(row + 1, 0), index(endRow, 0), {HiddenRole});
 }

--- a/qt/proofmodel.h
+++ b/qt/proofmodel.h
@@ -63,6 +63,9 @@ public:
     Q_INVOKABLE void updateLines();
     Q_INVOKABLE void updateRefs(int ln, bool op);
     Q_INVOKABLE void clearErrors();  // reset ErrorRole on every row
+    // Scrub every reference to lineNum (1-based) from ALL other lines.
+    // Safer than doing it from QML because there are no QVariant conversion issues.
+    Q_INVOKABLE void clearRefsToLine(int lineNum);
 
     // premiseCount — computed from the model data; read-only from QML.
     int  premiseCount() const;

--- a/qt/proofmodel.h
+++ b/qt/proofmodel.h
@@ -42,7 +42,9 @@ public:
         RefsRole,
         ErrorRole,      // carries pErrorMsg — "errMsg" in QML
         RuleCategoryRole,   // int 0-4 — locale-invariant outer combo index
-        RuleIndexRole       // int 0-N — locale-invariant inner combo index
+        RuleIndexRole,      // int 0-N — locale-invariant inner combo index
+        CollapsedRole,      // bool — true when this sf row is collapsed
+        HiddenRole          // bool (computed) — true when inside a collapsed subproof
     };
 
     // Basic functionality:
@@ -72,14 +74,18 @@ public:
 
     
     Q_INVOKABLE bool toggleLineType(int row);
-
     Q_INVOKABLE void recomputePremiseCount();
+    // Toggle collapsed state for a subproof-start row and refresh visibility
+    // of every row inside that block.  Safe to call from QML.
+    Q_INVOKABLE void toggleCollapsed(int row);
 
 signals:
     void premiseCountChanged(int n);
 
 private:
     void setPremiseCount(int n);
+    // Returns true if `row` is inside a currently collapsed subproof block.
+    bool isHiddenByCollapse(int row) const;
     ProofData *mLines;
     int  mPremiseCount = 1;
 


### PR DESCRIPTION
## Overview
This merge request introduces new export capabilities, UI improvements for proof readability, QML input macros, and resolves several bugs related to shortcuts and data integrity.

## Commits

* **[`704372b`] Add plain-text and Markdown export via unified Export dialog**
  Introduces a unified Export dialog to bring the user experience in line with the existing Import dialog. Adds support for exporting proofs to both plain-text and Markdown formats.

* **[`80fa384`] Add collapsible subproofs**
  Adds the ability to collapse and expand subproofs directly in the UI. This significantly improves readability and navigation when working with large and complex proofs.

* **[`6156266`] Add QML keyboard macros for single-character connectives**
  Implements instant conversion macros in QML. Typing single-character CLI connectives now instantly converts them into their corresponding graphical GUI symbols on the fly as you type.

* **[`160e732`, `cbd642f`] Fix outdated rule indices in example files**
  Corrects outdated rule indices in the `doc/proofs` example files to ensure they accurately match the current definitions found in the `rules.h` source file.

* **[`fcd53fb`] Fix shortcut conflicts, data corruption, and focus navigation**
  Resolves a critical issue that led to proof data corruption during line conversions. Additionally fixes cross-platform keyboard shortcut conflicts and improves general UI focus navigation