### PR TITLE
Production readiness: i18n support, export/UI polish, and critical engine/frontend bug fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,6 +41,14 @@ jobs:
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
+    - name: Run proof regression tests
+      # Exercises the shared C evaluation engine against every fixture in
+      # doc/proofs/ (propositional, predicate, boolean, ...). test-all.sh
+      # now exits non-zero on any regression so this step actually gates CI.
+      working-directory: ${{github.workspace}}/doc/proofs
+      shell: bash
+      run: bash test-all.sh ${{github.workspace}}/build/aris
+
 
   win64:
     runs-on: windows-latest

--- a/doc/proofs/test-all.sh
+++ b/doc/proofs/test-all.sh
@@ -36,3 +36,5 @@ for TLE in `find . -name '*.tle' -type f`; do
  N=$((N+1))
  done
 echo "$GOOD good (out of $N cases)"
+
+[ "$GOOD" -eq "$N" ] || exit 1

--- a/qt/DrawerTools.qml
+++ b/qt/DrawerTools.qml
@@ -61,7 +61,7 @@ ToolBar {
             icon.color: darkMode ? "white" : "black"
 
             onClicked: {
-                cConnector.evalText = "Evaluate Proof"
+                cConnector.evalText = qsTr("Evaluate Proof")
 
                 if (Qt.platform.os === "wasm") {
                     isExtFile = true

--- a/qt/KeyGroup.qml
+++ b/qt/KeyGroup.qml
@@ -133,7 +133,7 @@ ToolBar {
             ToolTip.text: cConnector.evalText
             background: Rectangle {
                 id: runButtonID
-                color: (cConnector.evalText === "Evaluate Proof") ? (darkMode ? "#BB86FC" : "white") : (cConnector.evalText === "Correct!") ? (darkMode ? "springgreen" : "green") : "red"
+                color: (cConnector.evalText === qsTr("Evaluate Proof")) ? (darkMode ? "#BB86FC" : "white") : (cConnector.evalText === qsTr("Correct!")) ? (darkMode ? "springgreen" : "green") : "red"
                 radius: 5
             }
 

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -812,23 +812,37 @@ Item {
                 // Indent unit U = scaledSpacing*2 per nesting level (zoom-aware).
                 // depth = model.ind / 20.
                 //
-                // sf rows:      spacer = (depth-1)*U + chevron(U) → depth*U total
-                // content rows: spacer =  depth*U                 → depth*U total
+                // The chevron slot below is a fixed-width Item that is always
+                // present (visible: true) for every row nested inside a
+                // subproof, whether or not THIS particular row owns the
+                // toggle — only the Button *inside* it toggles visibility.
+                // That keeps the RowLayout's shape (item count + spacing
+                // gaps) identical across sf and non-sf rows at the same
+                // depth, instead of relying on compensating for RowLayout's
+                // spacing/exclusion behavior around a conditionally-visible
+                // direct child.
                 //
-                // All line numbers at the same depth land at the same x position.
+                // spacer = (depth-1)*U, chevron slot = U → depth*U total,
+                // for every row at that depth.
                 Item {
-                    width:  Math.round((outerColumn.depthLevel - (model.subSt ? 1 : 0))
-                                       * outerColumn.indentUnit)
+                    width:  outerColumn.depthLevel > 0
+                            ? Math.round((outerColumn.depthLevel - 1) * outerColumn.indentUnit)
+                            : 0
                     height: 1
                 }
 
-                // Collapse chevron — only on sf rows; always exactly one indentUnit wide.
-                // ▶ = collapsed, ▼ = expanded.
-                Button {
-                    id: collapseToggleID
-                    visible: model.subSt === true
+                // Chevron slot — always present at depth > 0; the toggle
+                // button inside only draws on sf rows.
+                Item {
+                    id: chevronSlot
+                    visible: outerColumn.depthLevel > 0
                     width:   visible ? Math.round(outerColumn.indentUnit) : 0
                     height:  theTextID.height
+
+                Button {
+                    id: collapseToggleID
+                    anchors.fill: parent
+                    visible: model.subSt === true
 
                     // Always-visible background — subtle rounded rect, not flat.
                     background: Rectangle {
@@ -854,6 +868,7 @@ Item {
                     ToolTip.delay: 600
                     ToolTip.text: model.collapsed ? qsTr("Expand subproof") : qsTr("Collapse subproof")
                     onClicked: proofModel.toggleCollapsed(indexx)
+                }
                 }
 
 

--- a/qt/ProofArea.qml
+++ b/qt/ProofArea.qml
@@ -78,7 +78,7 @@ Item {
         listView.currentIndex = insertAt
 
         fileModified = true
-        cConnector.evalText = "Evaluate Proof"
+        cConnector.evalText = qsTr("Evaluate Proof")
         proofModel.clearErrors()
     }
 
@@ -103,7 +103,7 @@ Item {
         listView.currentIndex = insertAt2
 
         fileModified = true
-        cConnector.evalText = "Evaluate Proof"
+        cConnector.evalText = qsTr("Evaluate Proof")
         proofModel.clearErrors()
     }
 
@@ -242,7 +242,7 @@ Item {
             proofModel.updateRefs(insertAt, true)
             listView.currentIndex = insertAt
             fileModified = true
-            cConnector.evalText = "Evaluate Proof"
+            cConnector.evalText = qsTr("Evaluate Proof")
             proofModel.clearErrors()
         }
     }
@@ -270,7 +270,7 @@ Item {
             listView.currentIndex = insertIndex
             // premiseCount is recomputed automatically via postLineInsert signal.
             fileModified = true
-            cConnector.evalText = "Evaluate Proof"
+            cConnector.evalText = qsTr("Evaluate Proof")
             proofModel.clearErrors()
         }
     }
@@ -293,7 +293,7 @@ Item {
             proofModel.updateRefs(insertIndex, true)
             listView.currentIndex = insertIndex
             fileModified = true
-            cConnector.evalText = "Evaluate Proof"
+            cConnector.evalText = qsTr("Evaluate Proof")
             proofModel.clearErrors()
         }
     }
@@ -328,7 +328,7 @@ Item {
             }
             // premiseCount is recomputed automatically via postLineRemove signal.
             fileModified = true
-            cConnector.evalText = "Evaluate Proof"
+            cConnector.evalText = qsTr("Evaluate Proof")
             proofModel.clearErrors()
         }
     }
@@ -383,7 +383,7 @@ Item {
                     } else {
                         proofModel.toggleLineType(cur)
                         fileModified = true
-                        cConnector.evalText = "Evaluate Proof"
+                        cConnector.evalText = qsTr("Evaluate Proof")
                         proofModel.clearErrors()
                     }
                 } else {
@@ -403,7 +403,7 @@ Item {
                     // Boundary — atomic toggle.
                     proofModel.toggleLineType(cur)
                     fileModified = true
-                    cConnector.evalText = "Evaluate Proof"
+                    cConnector.evalText = qsTr("Evaluate Proof")
                     proofModel.clearErrors()
                 } else {
                     // Non-boundary — physical move to block boundary required.
@@ -488,7 +488,7 @@ Item {
                 proofModel.updateRefs(insertIndex, true)
                 listView.currentIndex = insertIndex
                 fileModified = true
-                cConnector.evalText = "Evaluate Proof"
+                cConnector.evalText = qsTr("Evaluate Proof")
                 proofModel.clearErrors()
             }
         }
@@ -507,7 +507,7 @@ Item {
                 proofModel.updateRefs(myIdx + 1, true)
                 listView.currentIndex = myIdx + 1
                 fileModified = true
-                cConnector.evalText = "Evaluate Proof"
+                cConnector.evalText = qsTr("Evaluate Proof")
                 proofModel.clearErrors()
             }
         }
@@ -525,7 +525,7 @@ Item {
                 proofModel.updateRefs(myIdx + 1, true)
                 listView.currentIndex = myIdx + 1
                 fileModified = true
-                cConnector.evalText = "Evaluate Proof"
+                cConnector.evalText = qsTr("Evaluate Proof")
                 proofModel.clearErrors()
             }
         }
@@ -552,7 +552,7 @@ Item {
                     listView.currentIndex = 0
                 }
                 fileModified = true
-                cConnector.evalText = "Evaluate Proof"
+                cConnector.evalText = qsTr("Evaluate Proof")
                 proofModel.clearErrors()
             }
         }
@@ -918,7 +918,7 @@ Item {
                         console.log("Invalid Operation: Invalid reference to subproof")
                         cConnector.evalText = "⚠ " + qsTr("Invalid Operation: Cannot reference lines across closed subproof boundaries.")
                     } else {
-                        cConnector.evalText = "Evaluate Proof"
+                        cConnector.evalText = qsTr("Evaluate Proof")
                             proofModel.clearErrors()
                         var array = Array.from(proofModel.data(
                                                    proofModel.index(
@@ -995,7 +995,7 @@ Item {
                     border.color: {
                         if (type === "comment")
                             return darkMode ? "#2A2A1E" : "#FFFDE7"
-                        if (cConnector.evalText === "Evaluate Proof")
+                        if (cConnector.evalText === qsTr("Evaluate Proof"))
                             return darkMode ? "white" : "black"
                         if (model.errMsg !== "")
                             return "red"
@@ -1353,7 +1353,7 @@ Item {
                                                    listView.currentIndex,
                                                    0), ar, 263)
                             fileModified = true
-                            cConnector.evalText = "Evaluate Proof"
+                            cConnector.evalText = qsTr("Evaluate Proof")
                             proofModel.clearErrors()
                         }
 
@@ -1410,7 +1410,7 @@ Item {
                             proofModel.updateLines()
                             proofModel.updateRefs(insertIndex, true)
                             listView.currentIndex = insertIndex
-                            cConnector.evalText = "Evaluate Proof"
+                            cConnector.evalText = qsTr("Evaluate Proof")
                             proofModel.clearErrors()
                         }
                     }
@@ -1425,7 +1425,7 @@ Item {
                             proofModel.updateLines()
                             proofModel.updateRefs(index + 1, true)
                             listView.currentIndex = index + 1
-                            cConnector.evalText = "Evaluate Proof"
+                            cConnector.evalText = qsTr("Evaluate Proof")
                             proofModel.clearErrors()
                         }
                     }
@@ -1439,7 +1439,7 @@ Item {
                             proofModel.updateLines()
                             proofModel.updateRefs(index + 1, true)
                             listView.currentIndex = index + 1
-                            cConnector.evalText = "Evaluate Proof"
+                            cConnector.evalText = qsTr("Evaluate Proof")
                             proofModel.clearErrors()
                         }
                     }
@@ -1489,7 +1489,7 @@ Item {
                             proofModel.updateLines()
                             proofModel.updateRefs(index + 1, true)
                             listView.currentIndex = index + 1
-                            cConnector.evalText = "Evaluate Proof"
+                            cConnector.evalText = qsTr("Evaluate Proof")
                             proofModel.clearErrors()
                         }
                     }
@@ -1507,7 +1507,7 @@ Item {
                             proofModel.updateLines()
                             proofModel.updateRefs(index + 1, true)
                             listView.currentIndex = index + 1
-                            cConnector.evalText = "Evaluate Proof"
+                            cConnector.evalText = qsTr("Evaluate Proof")
                             proofModel.clearErrors()
                         }
                     }
@@ -1517,7 +1517,7 @@ Item {
                         enabled: true
 
                         onTriggered: {
-                            cConnector.evalText = "Evaluate Proof"
+                            cConnector.evalText = qsTr("Evaluate Proof")
                             proofModel.clearErrors()
 
                             if (listView.count > 1) {

--- a/qt/auxconnector.cpp
+++ b/qt/auxconnector.cpp
@@ -686,6 +686,27 @@ static QTextDocument *buildProofDocument(const ProofData *pd)
     }
 
     // Data rows
+    // Both pSubStart and pSubEnd lines expand into TWO table rows:
+    //
+    //  pSubStart:
+    //    row A: "┌─ subproof" separator (no number, no rule, greyed)
+    //    row B: actual assumption line (number, formula, rule, refs)
+    //
+    //  pSubEnd:
+    //    row A: "└─" closing separator (no number, no rule, greyed)
+    //    row B: actual content line (number, formula, refs)
+    //
+    // Pre-count both so we can allocate the table with the correct total size.
+    int splitRowCount = 0;
+    for (int i = 0; i < n; ++i)
+        if (lines.at(i).pSubStart || lines.at(i).pSubEnd) ++splitRowCount;
+
+    // Resize the table: insertTable gave us n+1 rows (header + one per line).
+    // Each split row needs one additional row for its content.
+    for (int k = 0; k < splitRowCount; ++k)
+        table->appendRows(1);
+
+    int tableRow = 1;  // tracks next available data row (row 0 is the header)
     for (int i = 0; i < n; ++i) {
         const ProofLine &pl = lines.at(i);
         int depth = pl.pInd / 20;
@@ -693,20 +714,83 @@ static QTextDocument *buildProofDocument(const ProofData *pd)
         // Indentation prefix (em-space per depth level)
         QString indent = QString(QChar(0x2003)).repeated(depth);  // EM SPACE
 
-        // Formula cell
+        if (pl.pSubStart) {
+            // --- Row A: "┌─ subproof" separator header ---
+            QTextCursor sepCell = table->cellAt(tableRow, 1).firstCursorPosition();
+            QTextCharFormat sepFmt = normalFmt;
+            sepFmt.setForeground(QColor(100, 100, 100));
+            sepCell.insertText(indent + QStringLiteral("\u250c\u2500 subproof"), sepFmt);  // ┌─
+            ++tableRow;
+
+            // --- Row B: actual assumption line ---
+            QString formula = indent + (pl.pText.isEmpty() ? QStringLiteral("(empty)") : pl.pText);
+            QString rule = pl.pType == QLatin1String("premise") ? QStringLiteral("premise") : pl.pType;
+            if (rule == QLatin1String("choose") || rule == QLatin1String("sf")) rule = QStringLiteral("sf");
+            QStringList refStrs;
+            for (int r : pl.pRefs)
+                if (r != -1) refStrs << QString::number(r);
+            QString refs = refStrs.join(QStringLiteral(", "));
+
+            auto insertAssumCell = [&](int col, const QString &txt) {
+                QTextCursor c = table->cellAt(tableRow, col).firstCursorPosition();
+                c.insertText(txt, normalFmt);
+            };
+            insertAssumCell(0, QString::number(pl.pLine));
+            insertAssumCell(1, formula);
+            insertAssumCell(2, rule);
+            insertAssumCell(3, refs);
+            ++tableRow;
+            continue;
+        }
+
+        if (pl.pSubEnd) {
+            // --- Row A: "└─" closing separator ---
+            QTextCursor sepCell = table->cellAt(tableRow, 1).firstCursorPosition();
+            QTextCharFormat sepFmt = normalFmt;
+            sepFmt.setForeground(QColor(100, 100, 100));
+            // Use one shallower indent level for the bracket since the content
+            // inside the subproof is at `depth`, and the closer brackets inward.
+            QString closerIndent = depth > 0 ? QString(QChar(0x2003)).repeated(depth - 1) : QString();
+            sepCell.insertText(closerIndent + QStringLiteral("\u2514\u2500"), sepFmt);  // └─
+            ++tableRow;
+
+            // --- Row B: actual content of this line ---
+            if (!pl.pText.isEmpty()) {
+                QString formula = indent + pl.pText;
+                // "subproof" type is structural — suppress rule label.
+                QString rule;
+                if (pl.pType != QLatin1String("subproof") && pl.pType != QLatin1String("comment")) {
+                    rule = (pl.pType == QLatin1String("premise")) ? QStringLiteral("premise") : pl.pType;
+                    if (rule == QLatin1String("choose")) rule = QString();
+                }
+                QStringList refStrs;
+                for (int r : pl.pRefs)
+                    if (r != -1) refStrs << QString::number(r);
+                QString refs = refStrs.join(QStringLiteral(", "));
+
+                auto insertEndCell = [&](int col, const QString &txt) {
+                    QTextCursor c = table->cellAt(tableRow, col).firstCursorPosition();
+                    c.insertText(txt, normalFmt);
+                };
+                insertEndCell(0, QString::number(pl.pLine));
+                insertEndCell(1, formula);
+                insertEndCell(2, rule);
+                insertEndCell(3, refs);
+            }
+            ++tableRow;
+            continue;
+        }
+
+        // Formula cell (normal lines and comments)
         QString formula;
-        if (pl.pSubStart)
-            formula = indent + QStringLiteral("\u250c\u2500 subproof");  // ┌─
-        else if (pl.pSubEnd)
-            formula = indent + QStringLiteral("\u2514\u2500");            // └─
-        else if (pl.pType == QLatin1String("comment"))
+        if (pl.pType == QLatin1String("comment"))
             formula = indent + QStringLiteral("// ") + pl.pText;
         else
             formula = indent + (pl.pText.isEmpty() ? QStringLiteral("(empty)") : pl.pText);
 
         // Rule
         QString rule;
-        if (!pl.pSubStart && !pl.pSubEnd && pl.pType != QLatin1String("comment")) {
+        if (pl.pType != QLatin1String("comment")) {
             rule = (pl.pType == QLatin1String("premise")) ? QStringLiteral("premise") : pl.pType;
             if (rule == QLatin1String("choose")) rule = QString();
         }
@@ -718,17 +802,18 @@ static QTextDocument *buildProofDocument(const ProofData *pd)
         QString refs = refStrs.join(QStringLiteral(", "));
 
         auto insertCell = [&](int col, const QString &txt, bool italic = false) {
-            QTextCursor c = table->cellAt(i + 1, col).firstCursorPosition();
+            QTextCursor c = table->cellAt(tableRow, col).firstCursorPosition();
             QTextCharFormat f = normalFmt;
             if (italic) f.setFontItalic(true);
             if (pl.pType == QLatin1String("comment")) f.setForeground(QColor(128, 128, 128));
             c.insertText(txt, f);
         };
 
-        insertCell(0, pl.pSubStart || pl.pSubEnd || pl.pType == QLatin1String("comment") ? QString() : QString::number(pl.pLine));
+        insertCell(0, pl.pType == QLatin1String("comment") ? QString() : QString::number(pl.pLine));
         insertCell(1, formula, pl.pType == QLatin1String("comment"));
         insertCell(2, rule);
         insertCell(3, refs);
+        ++tableRow;
     }
 
     // Footer note

--- a/qt/auxconnector.cpp
+++ b/qt/auxconnector.cpp
@@ -316,7 +316,7 @@ void auxConnector::importProof(const QString &name, ProofData *pd, const Connect
  */
 void auxConnector::wasmImportProof(ProofData *pd, const Connector *c, ProofModel *pm)
 {
-    auto fileContentReady = [this, &c, &pd, &pm](const QString &fileName, const QByteArray &fileContent) {
+    auto fileContentReady = [this, c, pd, pm](const QString &fileName, const QByteArray &fileContent) {
         if (fileName.isEmpty()) {
             qDebug() << "No file was selected" ;
             emit importFinished(false);
@@ -363,8 +363,8 @@ void auxConnector::importProofWithMode(const QString &name, ProofData *pd, const
                        line.pSub, line.pSubStart, line.pSubEnd, line.pInd, refs,
                        line.pRuleCategory, line.pRuleIndex);
 
-        if (line.fname)
-            pd->setFile(targetIndex, QString::fromUtf8((const char *) line.fname));
+        if (!line.fname.isEmpty())
+            pd->setFile(targetIndex, line.fname);
     }
 
     pm->updateLines();
@@ -375,7 +375,8 @@ void auxConnector::importProofWithMode(const QString &name, ProofData *pd, const
 
 void auxConnector::wasmImportProofWithMode(ProofData *pd, const Connector *c, ProofModel *pm, int mode)
 {
-    auto fileContentReady = [this, &c, &pd, &pm, mode](const QString &fileName, const QByteArray &fileContent) {
+    // Capture pointers by value — see wasmImportProof() above for why.
+    auto fileContentReady = [this, c, pd, pm, mode](const QString &fileName, const QByteArray &fileContent) {
         if (fileName.isEmpty()) {
             qDebug() << "No file was selected" ;
             emit importFinished(false);

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -80,7 +80,7 @@ void releaseCProof(proof_t *&proof)
 } 
 
 Connector::Connector(QObject *parent)
-    : QObject{parent}, m_evalText{"Evaluate Proof"}, cProof(nullptr), returns(nullptr)
+    : QObject{parent}, m_evalText{tr("Evaluate Proof")}, cProof(nullptr), returns(nullptr)
 {   
     // Initialize rulesMap
 
@@ -408,7 +408,10 @@ int Connector::evalProof(const ProofData *toBeEval, const GoalData *gls, ProofMo
             // qsTr() calls used for the same rule names in the rule dropdown (ProofArea.qml).
             QString ruleEnglish = reverseRulesMap.value(sd->rule, QStringLiteral("?"));
             QString ruleName = QCoreApplication::translate("ProofArea", ruleEnglish.toUtf8().constData());
-            QString message  = QString::fromUtf8(cur_ret);
+            // Backend validation strings come from the gettext-wrapped aris/src C
+            // engine, which lupdate cannot scan. Route the literal through Qt's own
+            // translation table (context "ProofErrors") using it as the msgid instead.
+            QString message  = QCoreApplication::translate("ProofErrors", cur_ret);
             QString fullMsg  = tr("Line %1 · %2: %3")
                                    .arg(lineNum)
                                    .arg(ruleName)
@@ -426,7 +429,7 @@ int Connector::evalProof(const ProofData *toBeEval, const GoalData *gls, ProofMo
     }
 
     // evalText stays as the global status,  detail is now in the model.
-    setEvalText(anyError ? QStringLiteral("Errors found") : QStringLiteral("Correct!"));
+    setEvalText(anyError ? tr("Errors found") : tr("Correct!"));
 
     return 1;
 }

--- a/qt/connector.cpp
+++ b/qt/connector.cpp
@@ -257,6 +257,8 @@ void Connector::genProof(const ProofData *toBeEval)
     //  ProofData::lines() returns by value (full copy).
     const QVector<ProofLine> snap = toBeEval->lines();
 
+    bool usesBooleanRule = false;
+
     for (int i = 0; i < snap.size(); i++) {
         const ProofLine &pl = snap.at(i);   // const-ref into the snapshot — zero copies
 
@@ -286,6 +288,8 @@ void Connector::genProof(const ProofData *toBeEval)
         if (rule == RULE_UNKNOWN)
             rule = -1;
 
+        if (rule >= 34 && rule <= 37)
+            usesBooleanRule = true;
 
         // Assign Indices
         for (int ii = 0; ii < m_indices[i].size(); ii++)
@@ -320,8 +324,14 @@ void Connector::genProof(const ProofData *toBeEval)
             temp_refs[pl.pRefs.size() - 1] = REF_END;
         }
 
+        // sen_data_init() strdup's `file` internally, so the QByteArray only
+        // needs to outlive this call.
+        QByteArray fnameUtf8 = pl.fname.toUtf8();
         sen_data *sd = sen_data_init(i + 1, rule, (unsigned char *) str.c_str(), temp_refs,
-                                     premise, pl.fname, subproof, depth, NULL);
+                                     premise,
+                                     pl.fname.isEmpty() ? nullptr : (unsigned char *) fnameUtf8.constData(),
+                                     subproof, depth, NULL);
+        free(temp_refs);
         if (!sd) {
             free(ind);
             qDebug() << "proof: could not initialize sen_data";
@@ -337,8 +347,7 @@ void Connector::genProof(const ProofData *toBeEval)
             qDebug() << "proof: could not insert sen_data";
     }
 
-    // TODO : Fix boolean
-    cProof->boolean = 0;
+    cProof->boolean = usesBooleanRule ? 1 : 0;
 }
 
 
@@ -549,7 +558,7 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
         openTo->insertLine(sd->line_num-1, sd->line_num, (const char *) sd->text,
                            reverseRulesMap[effectiveRule], (sd->depth > 0),
                            (effectiveRule == -2),
-                           (sd->line_num != 1 && ((sen_data *) pf_itr->prev->value)->depth > sd->depth),
+                           (pf_itr->prev && ((sen_data *) pf_itr->prev->value)->depth > sd->depth),
                            sd->depth * 20, temp_refs,
                            ci.first, ci.second);
         d = sd->depth;
@@ -596,7 +605,7 @@ void Connector::openProof(const QString &name, ProofData *openTo, GoalData *gls)
  */
 void Connector::wasmOpenProof(ProofData *open, GoalData *gls)
 {
-    auto fileContentReady = [&open, this, &gls](const QString &fileName, const QByteArray &fileContent) {
+    auto fileContentReady = [open, this, gls](const QString &fileName, const QByteArray &fileContent) {
         if (fileName.isEmpty()) {
             qDebug() << "No file was selected" ;
         } else {
@@ -743,8 +752,22 @@ void Connector::smartPaste(ProofData *pd, ProofModel *pm)
         pd->removeLineAt(0);
 
     int insertIdx = 0;
+    // Tracks the subproof nesting depth of the previously-inserted line so
+    // indentation on pasted text can be mapped to Aris's sf/subproof-end
+    // structure instead of flattening everything to depth 0.
+    int prevDepth = 0;
 
     for (const QString &rawLine : lines) {
+        // Measure leading indentation on the RAW line, before trimming
+        // discards it — 4 spaces (or 1 tab, expanded to 4) per depth level.
+        int leadingWs = 0;
+        for (const QChar &ch : rawLine) {
+            if (ch == QLatin1Char('\t')) leadingWs += 4;
+            else if (ch == QLatin1Char(' ')) leadingWs += 1;
+            else break;
+        }
+        const int depth = leadingWs / 4;
+
         QString line = rawLine.trimmed();
         if (line.isEmpty()) continue;
 
@@ -811,7 +834,8 @@ void Connector::smartPaste(ProofData *pd, ProofModel *pm)
         }
 
         const bool isKnownRule = ruleAliases.values().contains(foundRule);
-        if (refs.size() == 1 && !foundRule.isEmpty() && isKnownRule
+        const bool ambiguousShortAlias = isKnownRule && bestRuleIndex != -1 && bestAlias.length() <= 3;
+        if (refs.size() == 1 && !foundRule.isEmpty() && ambiguousShortAlias
             && foundRule != QLatin1String("sf")
             && foundRule != QLatin1String("subproof"))
             foundRule = QStringLiteral("premise");
@@ -840,11 +864,17 @@ void Connector::smartPaste(ProofData *pd, ProofModel *pm)
         line.replace(reEx,       QStringLiteral("∃\\1"));
         // Aris requires parentheses wrapping the predicate after a quantifier.
         line.replace(reQuantParen, QStringLiteral("\\1\\2(\\3)"));
+        const bool isSubStart = depth > prevDepth;
+        const bool isSubEnd   = depth < prevDepth;
+        if (isSubStart)
+            foundRule = QStringLiteral("sf");
+        prevDepth = depth;
 
         //  Per-line debug logging only in debug builds.
 #ifndef QT_NO_DEBUG
         qDebug() << "[SmartPaste] Inserting at" << insertIdx
-                 << "text:" << line << "rule:" << foundRule << "refs:" << refs;
+                 << "text:" << line << "rule:" << foundRule << "refs:" << refs
+                 << "depth:" << depth;
 #endif
 
         //  Pass line (QString) directly — insertLine already takes QString.
@@ -854,7 +884,8 @@ void Connector::smartPaste(ProofData *pd, ProofModel *pm)
             // populated immediately on paste, not lazily by the combo binding.
             int ruleId = rulesMap.value(foundRule, -1);
             auto ci = getCategoryAndIndex(ruleId);
-            pd->insertLine(insertIdx, insertIdx + 1, line, foundRule, false, false, false, 0, refs,
+            pd->insertLine(insertIdx, insertIdx + 1, line, foundRule,
+                           depth > 0, isSubStart, isSubEnd, depth * 20, refs,
                            ci.first, ci.second);
         }
         insertIdx++;

--- a/qt/goalmodel.cpp
+++ b/qt/goalmodel.cpp
@@ -29,7 +29,7 @@ int GoalModel::rowCount(const QModelIndex &parent) const
 {
     // For list models only the root node (an invalid parent) should return the list's size. For all
     // other (valid) parents, rowCount() should return 0 so that it does not become a tree model.
-    if (parent.isValid())
+    if (parent.isValid() || !m_glines)
         return 0;
 
     return m_glines->glines().size();

--- a/qt/i18n/aris-qt_ar.ts
+++ b/qt/i18n/aris-qt_ar.ts
@@ -2,175 +2,1516 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ar_SA" sourcelanguage="en_US">
 <context>
-    <name>KeyGroup</name>
+    <name>Connector</name>
     <message>
-        <source>Conjunction</source>
-        <translation>اقتران</translation>
+        <location filename="../connector.cpp" line="415"/>
+        <source>Line %1 · %2: %3</source>
+        <translation>السطر %1 · %2: %3</translation>
     </message>
     <message>
-        <source>Disjunction</source>
-        <translation>انفصال</translation>
+        <location filename="../connector.cpp" line="481"/>
+        <source>File save failed for path: %1</source>
+        <translation>فشل حفظ الملف في المسار: %1</translation>
     </message>
     <message>
-        <source>Negation</source>
-        <translation>نفي</translation>
+        <location filename="../connector.cpp" line="514"/>
+        <source>File open failed for path: %1</source>
+        <translation>فشل فتح الملف في المسار: %1</translation>
     </message>
     <message>
-        <source>Implication</source>
-        <translation>استلزام</translation>
+        <source>Evaluate Proof</source>
+        <translation>تقييم الإثبات</translation>
     </message>
     <message>
-        <source>Bi-conditional</source>
-        <translation>ثنائي الشرط</translation>
+        <source>Correct!</source>
+        <translation>صحيح!</translation>
     </message>
     <message>
-        <source>For all</source>
-        <translation>لكل</translation>
-    </message>
-    <message>
-        <source>There exists</source>
-        <translation>يوجد</translation>
-    </message>
-    <message>
-        <source>Tautology</source>
-        <translation>تحصيل حاصل</translation>
-    </message>
-    <message>
-        <source>Contradiction</source>
-        <translation>تناقض</translation>
-    </message>
-    <message>
-        <source>Belongs To</source>
-        <translation>ينتمي إلى</translation>
-    </message>
-    <message>
-        <source>Null</source>
-        <translation>خالي</translation>
-    </message>
-    <message>
-        <source>XOR</source>
-        <translation>فصل حصري</translation>
+        <source>Errors found</source>
+        <translation>توجد أخطاء</translation>
     </message>
 </context>
 <context>
     <name>DrawerTools</name>
-    <message><source>New</source><translation>جديد</translation></message>
-    <message><source>Reset</source><translation>إعادة ضبط</translation></message>
-    <message><source>Open</source><translation>فتح</translation></message>
-    <message><source>Save</source><translation>حفظ</translation></message>
-    <message><source>Save As</source><translation>حفظ باسم</translation></message>
-    <message><source>Export To LaTeX</source><translation>تصدير إلى LaTeX</translation></message>
-    <message><source>Toggle Goals</source><translation>تبديل الأهداف</translation></message>
-    <message><source>Toggle Dark Mode</source><translation>تبديل الوضع الداكن</translation></message>
-    <message><source>Zoom</source><translation>تكبير</translation></message>
-    <message><source>Reset Zoom</source><translation>إعادة ضبط التكبير</translation></message>
-    <message><source>Paste Proof from Clipboard</source><translation>لصق الإثبات من الحافظة</translation></message>
     <message>
+        <location filename="../DrawerTools.qml" line="37"/>
+        <source>New</source>
+        <translation>جديد</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="50"/>
+        <source>Reset</source>
+        <translation>إعادة ضبط</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="59"/>
+        <source>Open</source>
+        <translation>فتح</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="77"/>
+        <source>Save</source>
+        <translation>حفظ</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="96"/>
+        <source>Save As</source>
+        <translation>حفظ باسم</translation>
+    </message>
+    <message>
+        <source>Export To LaTeX</source>
+        <translation type="vanished">تصدير إلى LaTeX</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="107"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="122"/>
+        <source>Toggle Goals</source>
+        <translation>تبديل الأهداف</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="136"/>
+        <source>Toggle Dark Mode</source>
+        <translation>تبديل الوضع الداكن</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="164"/>
+        <source>Zoom</source>
+        <translation>تكبير</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="213"/>
+        <source>Reset Zoom</source>
+        <translation>إعادة ضبط التكبير</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="220"/>
+        <source>Paste Proof from Clipboard</source>
+        <translation>لصق الإثبات من الحافظة</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="226"/>
         <source>(Ctrl+Shift+V)</source>
         <translation>(Ctrl+Shift+V)</translation>
     </message>
-    <message><source>Copy Selected Lines</source><translation>نسخ الأسطر المحددة</translation></message>
     <message>
+        <location filename="../DrawerTools.qml" line="235"/>
+        <source>Copy Selected Lines</source>
+        <translation>نسخ الأسطر المحددة</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="241"/>
         <source>(Ctrl+Shift+C)</source>
         <translation>(Ctrl+Shift+C)</translation>
     </message>
-    <message><source>Import Proof</source><translation>استيراد إثبات</translation></message>
-    <message><source>Font</source><translation>خط</translation></message>
-    <message><source>Language</source><translation>لغة</translation></message>
-    <message><source>Help</source><translation>مساعدة</translation></message>
-    <message><source>About</source><translation>حول</translation></message>
+    <message>
+        <location filename="../DrawerTools.qml" line="250"/>
+        <source>Import Proof</source>
+        <translation>استيراد إثبات</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="262"/>
+        <source>Font</source>
+        <translation>خط</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="272"/>
+        <source>Language</source>
+        <translation>لغة</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="315"/>
+        <source>Help</source>
+        <translation>مساعدة</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="323"/>
+        <source>About</source>
+        <translation>حول</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>تقييم الإثبات</translation>
+    </message>
+</context>
+<context>
+    <name>GoalLine</name>
+    <message>
+        <location filename="../GoalLine.qml" line="163"/>
+        <source>Invalid Operation: At least one goal line must remain.</source>
+        <translation>عملية غير صالحة: يجب أن يبقى سطر هدف واحد على الأقل.</translation>
+    </message>
+</context>
+<context>
+    <name>KeyGroup</name>
+    <message>
+        <location filename="../KeyGroup.qml" line="37"/>
+        <source>Conjunction</source>
+        <translation>اقتران</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="44"/>
+        <source>Disjunction</source>
+        <translation>انفصال</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="51"/>
+        <source>Negation</source>
+        <translation>نفي</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="58"/>
+        <source>Implication</source>
+        <translation>استلزام</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="65"/>
+        <source>Bi-conditional</source>
+        <translation>ثنائي الشرط</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="72"/>
+        <source>For all</source>
+        <translation>لكل</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="79"/>
+        <source>There exists</source>
+        <translation>يوجد</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="86"/>
+        <source>Tautology</source>
+        <translation>تحصيل حاصل</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="93"/>
+        <source>Contradiction</source>
+        <translation>تناقض</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="100"/>
+        <source>Belongs To</source>
+        <translation>ينتمي إلى</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="107"/>
+        <source>Null</source>
+        <translation>خالي</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="114"/>
+        <source>XOR</source>
+        <translation>فصل حصري</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>تقييم الإثبات</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>صحيح!</translation>
+    </message>
+</context>
+<context>
+    <name>ProofArea</name>
+    <message>
+        <location filename="../ProofArea.qml" line="606"/>
+        <source>Confirm Conversion</source>
+        <translation>تأكيد التحويل</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="623"/>
+        <source>Cancel</source>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="635"/>
+        <source>Convert Anyway</source>
+        <translation>التحويل على أي حال</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="439"/>
+        <source>Convert</source>
+        <translation>تحويل</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="226"/>
+        <location filename="../ProofArea.qml" line="261"/>
+        <location filename="../ProofArea.qml" line="285"/>
+        <location filename="../ProofArea.qml" line="313"/>
+        <location filename="../ProofArea.qml" line="353"/>
+        <source>No line selected.</source>
+        <translation>لم يتم تحديد أي سطر.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="362"/>
+        <source>Cannot convert structural subproof lines.</source>
+        <translation>لا يمكن تحويل أسطر الإثبات الفرعي البنيوية.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="369"/>
+        <source>Proof must contain at least one premise.</source>
+        <translation>يجب أن يحتوي الإثبات على فرضية واحدة على الأقل.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="441"/>
+        <location filename="../ProofArea.qml" line="1448"/>
+        <source>Convert to Conclusion</source>
+        <translation>تحويل إلى استنتاج</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="441"/>
+        <location filename="../ProofArea.qml" line="1448"/>
+        <source>Convert to Premise</source>
+        <translation>تحويل إلى فرضية</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="480"/>
+        <source>Add Premise Above</source>
+        <translation>إضافة فرضية أعلى</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="498"/>
+        <source>Add Conclusion Below</source>
+        <translation>إضافة استنتاج أسفل</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="517"/>
+        <source>Add Comment Below</source>
+        <translation>إضافة تعليق أسفل</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="869"/>
+        <source>Expand subproof</source>
+        <translation>توسيع الإثبات الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="869"/>
+        <source>Collapse subproof</source>
+        <translation>طي الإثبات الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="901"/>
+        <source>Invalid Operation: A proof line can only reference earlier line numbers.</source>
+        <translation>عملية غير صالحة: لا يمكن لسطر الإثبات أن يشير إلا إلى أرقام أسطر سابقة.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="906"/>
+        <source>Invalid Operation: Cannot assign inference rules or references to a premise.</source>
+        <translation>عملية غير صالحة: لا يمكن تعيين قواعد استدلال أو مراجع لفرضية.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="912"/>
+        <source>Invalid Operation: Cannot modify or reference the start line of a subproof directly.</source>
+        <translation>عملية غير صالحة: لا يمكن تعديل سطر بداية الإثبات الفرعي أو الإشارة إليه مباشرة.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="919"/>
+        <source>Invalid Operation: Cannot reference lines across closed subproof boundaries.</source>
+        <translation>عملية غير صالحة: لا يمكن الإشارة إلى أسطر عبر حدود إثبات فرعي مغلق.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1404"/>
+        <source>Add Premise</source>
+        <translation>إضافة فرضية</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1418"/>
+        <source>Add Conclusion</source>
+        <translation>إضافة استنتاج</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1434"/>
+        <source>Add Comment</source>
+        <translation>إضافة تعليق</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1484"/>
+        <source>Start Subproof</source>
+        <translation>بدء إثبات فرعي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1498"/>
+        <source>End Subproof</source>
+        <translation>إنهاء الإثبات الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1516"/>
+        <source>Remove this Line</source>
+        <translation>إزالة هذا السطر</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1172"/>
+        <source>premise</source>
+        <translation>فرضية</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1173"/>
+        <source>subproof</source>
+        <translation>إثبات فرعي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1174"/>
+        <source>sf</source>
+        <translation>إ.ف</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <source>Inference</source>
+        <translation>استدلال</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Equivalence</source>
+        <translation>تكافؤ</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <source>Predicate</source>
+        <translation>محمول</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <source>Miscellaneous</source>
+        <translation>متنوع</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <source>Boolean</source>
+        <translation>منطقي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Modus Ponens</source>
+        <translation>قياس استثنائي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Addition</source>
+        <translation>إضافة</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Simplification</source>
+        <translation>تبسيط</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Conjunction</source>
+        <translation>اقتران</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Hypothetical Syllogism</source>
+        <translation>قياس شرطي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Disjunctive Syllogism</source>
+        <translation>قياس منفصل</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Excluded middle</source>
+        <translation>الثالث المرفوع</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Constructive Dilemma</source>
+        <translation>معضلة بناءة</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>XOR Introduction</source>
+        <translation>إدخال الفصل الحصري</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>XOR Elimination</source>
+        <translation>إزالة الفصل الحصري</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Implication</source>
+        <translation>استلزام</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>DeMorgan</source>
+        <translation>دي مورغان</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Association</source>
+        <translation>تجميع</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Commutativity</source>
+        <translation>تبديل</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Idempotence</source>
+        <translation>تساوي القوى</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Distribution</source>
+        <translation>توزيع</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Double Negation</source>
+        <translation>نفي مزدوج</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Exportation</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Subsumption</source>
+        <translation>إدراج</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Contrapositive</source>
+        <translation>عكس نقيض</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Universal Generalization</source>
+        <translation>تعميم كلي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Universal Instantiation</source>
+        <translation>تخصيص كلي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Existential Generalization</source>
+        <translation>تعميم وجودي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Existential Instantiation</source>
+        <translation>تخصيص وجودي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Bound Variable Substitution</source>
+        <translation>استبدال متغير مقيد</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Null Quantifier</source>
+        <translation>مكمم صفري</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Prenex</source>
+        <translation>صيغة برينكس</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Identity</source>
+        <translation>تطابق</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Free Variable Substitution</source>
+        <translation>استبدال متغير حر</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="122"/>
+        <source>Lemma</source>
+        <translation>تمهيدية</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="122"/>
+        <source>Subproof</source>
+        <translation>إثبات فرعي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="122"/>
+        <source>Sequence</source>
+        <translation>تسلسل</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="122"/>
+        <source>Induction</source>
+        <translation>استقراء</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="123"/>
+        <source>Identity </source>
+        <translation>تطابق </translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="123"/>
+        <source>Negation</source>
+        <translation>نفي</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="123"/>
+        <source>Dominance</source>
+        <translation>هيمنة</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="123"/>
+        <source>Symbol Negation</source>
+        <translation>نفي الرمز</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>تقييم الإثبات</translation>
+    </message>
+</context>
+<context>
+    <name>auxConnector</name>
+    <message>
+        <location filename="../auxconnector.cpp" line="122"/>
+        <source>LaTeX export failed: could not convert proof to LaTeX format.</source>
+        <translation>فشل تصدير LaTeX: تعذر تحويل الإثبات إلى تنسيق LaTeX.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="165"/>
+        <source>Import failed: the selected file could not be opened or is not a valid Aris proof.</source>
+        <translation>فشل الاستيراد: تعذر فتح الملف المحدد أو أنه ليس إثبات Aris صالحًا.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="481"/>
+        <source>Text export failed: could not open &apos;%1&apos; for writing.</source>
+        <translation>فشل تصدير النص: تعذر فتح ‎&apos;%1&apos;‎ للكتابة.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="551"/>
+        <source>Markdown export failed: could not open &apos;%1&apos; for writing.</source>
+        <translation>فشل تصدير Markdown: تعذر فتح ‎&apos;%1&apos;‎ للكتابة.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="855"/>
+        <source>ODT export failed: could not write to &apos;%1&apos;.</source>
+        <translation>فشل تصدير ODT: تعذرت الكتابة إلى ‎&apos;%1&apos;‎.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="896"/>
+        <source>PDF export is not available on your device.</source>
+        <translation>تصدير PDF غير متاح على هذا الجهاز.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="915"/>
+        <source>PDF export failed: could not write to &apos;%1&apos;.</source>
+        <translation>فشل تصدير PDF: تعذرت الكتابة إلى ‎&apos;%1&apos;‎.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="933"/>
+        <source>PDF export is not available in the browser version.</source>
+        <translation>تصدير PDF غير متاح في نسخة المتصفح.</translation>
+    </message>
 </context>
 <context>
     <name>main</name>
     <message>
+        <location filename="../main.qml" line="166"/>
+        <source>Got it</source>
+        <translation>فهمت</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="201"/>
         <source>QT_LAYOUT_DIRECTION</source>
         <comment>QGuiApplication</comment>
         <translation>RTL</translation>
     </message>
-    <message><source>Unsaved changes</source><translation>تغييرات غير محفوظة</translation></message>
-    <message><source>Save file before closing?</source><translation>هل تريد حفظ الملف قبل الإغلاق؟</translation></message>
-    <message><source>Save new file before closing?</source><translation>هل تريد حفظ الملف الجديد قبل الإغلاق؟</translation></message>
-    <message><source>Reset the current proof and goals?</source><translation>إعادة ضبط الإثبات والأهداف الحالية؟</translation></message>
-    <message><source>Cancel</source><translation>إلغاء</translation></message>
-    <message><source>Reset</source><translation>إعادة ضبط</translation></message>
-    <message><source>Choose import behavior</source><translation>اختر سلوك الاستيراد</translation></message>
-    <message><source>Overwrite</source><translation>استبدال</translation></message>
-    <message><source>Append End</source><translation>إلحاق في النهاية</translation></message>
-    <message><source>Prepend</source><translation>إضافة في البداية</translation></message>
+    <message>
+        <location filename="../main.qml" line="563"/>
+        <source>Unsaved changes</source>
+        <translation>تغييرات غير محفوظة</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="593"/>
+        <source>Save file before closing?</source>
+        <translation>هل تريد حفظ الملف قبل الإغلاق؟</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
+        <source>Save new file before closing?</source>
+        <translation>هل تريد حفظ الملف الجديد قبل الإغلاق؟</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="628"/>
+        <source>Reset the current proof and goals?</source>
+        <translation>إعادة ضبط الإثبات والأهداف الحالية؟</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="637"/>
+        <location filename="../main.qml" line="1093"/>
+        <source>Cancel</source>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="649"/>
+        <source>Reset</source>
+        <translation>إعادة ضبط</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="696"/>
+        <source>Choose import behavior</source>
+        <translation>اختر سلوك الاستيراد</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="705"/>
+        <source>Overwrite</source>
+        <translation>استبدال</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="717"/>
+        <source>Append End</source>
+        <translation>إلحاق في النهاية</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="729"/>
+        <source>Prepend</source>
+        <translation>إضافة في البداية</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="774"/>
+        <source>Choose export format</source>
+        <translation>اختيار تنسيق التصدير</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="783"/>
+        <source>LaTeX</source>
+        <translation>LaTeX</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="799"/>
+        <source>Plain Text</source>
+        <translation>نص عادي</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="815"/>
+        <source>Markdown</source>
+        <translation>Markdown</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="869"/>
+        <source>Choose save format</source>
+        <translation>اختيار تنسيق الحفظ</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="881"/>
+        <source>Aris (.tle)</source>
+        <translation>Aris (.tle)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="904"/>
+        <source>ODT (.odt)</source>
+        <translation>ODT (.odt)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="926"/>
+        <source>PDF (.pdf)</source>
+        <translation>PDF (.pdf)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1014"/>
+        <source>Jump to Line</source>
+        <translation>الانتقال إلى سطر</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1026"/>
+        <source>Invalid line number. Must be between 1 and </source>
+        <translation>رقم سطر غير صالح. يجب أن يكون بين 1 و </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1054"/>
+        <source>Line number</source>
+        <translation>رقم السطر</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1103"/>
+        <source>Jump</source>
+        <translation>انتقال</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>تقييم الإثبات</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>صحيح!</translation>
+    </message>
+    <message>
+        <source>Errors found</source>
+        <translation>توجد أخطاء</translation>
+    </message>
+    <message>
+        <source>Errors found — see inline details above each failing line.</source>
+        <translation>توجد أخطاء — راجع التفاصيل فوق كل سطر خاطئ.</translation>
+    </message>
 </context>
 <context>
-    <name>ProofArea</name>
-    <message><source>Confirm Conversion</source><translation>تأكيد التحويل</translation></message>
-    <message><source>Cancel</source><translation>إلغاء</translation></message>
-    <message><source>Convert Anyway</source><translation>التحويل على أي حال</translation></message>
-    <message><source>Convert</source><translation>تحويل</translation></message>
-    <message><source>Convert to Conclusion</source><translation>تحويل إلى استنتاج</translation></message>
-    <message><source>Convert to Premise</source><translation>تحويل إلى فرضية</translation></message>
-
-    <message><source>Add Premise Above</source><translation>إضافة فرضية أعلى</translation></message>
-    <message><source>Add Conclusion Below</source><translation>إضافة استنتاج أسفل</translation></message>
-    <message><source>Add Premise</source><translation>إضافة فرضية</translation></message>
-    <message><source>Add Conclusion</source><translation>إضافة استنتاج</translation></message>
-    <message><source>Start Subproof</source><translation>بدء إثبات فرعي</translation></message>
-    <message><source>End Subproof</source><translation>إنهاء الإثبات الفرعي</translation></message>
-    <message><source>Remove this Line</source><translation>إزالة هذا السطر</translation></message>
-
-    <message><source>premise</source><translation>فرضية</translation></message>
-    <message><source>subproof</source><translation>إثبات فرعي</translation></message>
+    <name>ProofErrors</name>
     <message>
-        <source>sf</source>
-        <translation>إ.ف</translation>
+        <source>A proof must be specified.</source>
+        <translation>يجب تحديد إثبات.</translation>
     </message>
-
-    <message><source>Inference</source><translation>استدلال</translation></message>
-    <message><source>Equivalence</source><translation>تكافؤ</translation></message>
-    <message><source>Predicate</source><translation>محمول</translation></message>
-    <message><source>Miscellaneous</source><translation>متنوع</translation></message>
-    <message><source>Boolean</source><translation>منطقي</translation></message>
-
-    <message><source>Modus Ponens</source><translation>قياس استثنائي</translation></message>
-    <message><source>Addition</source><translation>إضافة</translation></message>
-    <message><source>Simplification</source><translation>تبسيط</translation></message>
-    <message><source>Conjunction</source><translation>اقتران</translation></message>
-    <message><source>Hypothetical Syllogism</source><translation>قياس شرطي</translation></message>
-    <message><source>Disjunctive Syllogism</source><translation>قياس منفصل</translation></message>
-    <message><source>Excluded middle</source><translation>الثالث المرفوع</translation></message>
-    <message><source>Constructive Dilemma</source><translation>معضلة بناءة</translation></message>
-    <message><source>XOR Introduction</source><translation>إدخال الفصل الحصري</translation></message>
-    <message><source>XOR Elimination</source><translation>إزالة الفصل الحصري</translation></message>
-
-    <message><source>Implication</source><translation>استلزام</translation></message>
-    <message><source>DeMorgan</source><translation>دي مورغان</translation></message>
-    <message><source>Association</source><translation>تجميع</translation></message>
-    <message><source>Commutativity</source><translation>تبديل</translation></message>
-    <message><source>Idempotence</source><translation>تساوي القوى</translation></message>
-    <message><source>Distribution</source><translation>توزيع</translation></message>
-    <message><source>Double Negation</source><translation>نفي مزدوج</translation></message>
-    <message><source>Exportation</source><translation>تصدير</translation></message>
-    <message><source>Subsumption</source><translation>إدراج</translation></message>
-    <message><source>Contrapositive</source><translation>عكس نقيض</translation></message>
-
-    <message><source>Universal Generalization</source><translation>تعميم كلي</translation></message>
-    <message><source>Universal Instantiation</source><translation>تخصيص كلي</translation></message>
-    <message><source>Existential Generalization</source><translation>تعميم وجودي</translation></message>
-    <message><source>Existential Instantiation</source><translation>تخصيص وجودي</translation></message>
-    <message><source>Bound Variable Substitution</source><translation>استبدال متغير مقيد</translation></message>
-    <message><source>Null Quantifier</source><translation>مكمم صفري</translation></message>
-    <message><source>Prenex</source><translation>صيغة برينكس</translation></message>
-    <message><source>Identity</source><translation>تطابق</translation></message>
-    <message><source>Free Variable Substitution</source><translation>استبدال متغير حر</translation></message>
-
-    <message><source>Lemma</source><translation>تمهيدية</translation></message>
-    <message><source>Subproof</source><translation>إثبات فرعي</translation></message>
-    <message><source>Sequence</source><translation>تسلسل</translation></message>
-    <message><source>Induction</source><translation>استقراء</translation></message>
-
     <message>
-        <source>Identity </source>
-        <translation>تطابق </translation>
+        <source>A tautology must be matched with a conjunction, and a contradiction with a disjunction.</source>
+        <translation>يجب أن يطابق التحصيل الحاصل اقترانًا، وأن يطابق التناقض فصلًا.</translation>
     </message>
-    <message><source>Negation</source><translation>نفي</translation></message>
-    <message><source>Dominance</source><translation>هيمنة</translation></message>
-    <message><source>Symbol Negation</source><translation>نفي الرمز</translation></message>
+    <message>
+        <source>Addition requires one (1) reference.</source>
+        <translation>تتطلب الإضافة مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>All of the references except the disjunction reference must contain a conditional.</source>
+        <translation>يجب أن تحتوي جميع المراجع باستثناء مرجع الفصل على شرطية.</translation>
+    </message>
+    <message>
+        <source>All of the references must be used.</source>
+        <translation>يجب استخدام جميع المراجع.</translation>
+    </message>
+    <message>
+        <source>All of the references must contain a conditional.</source>
+        <translation>يجب أن تحتوي جميع المراجع على شرطية.</translation>
+    </message>
+    <message>
+        <source>Association constructed incorrectly.</source>
+        <translation>تم بناء التجميع بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Association must be done on a conjunction or disjunction.</source>
+        <translation>يجب أن يتم التجميع على اقتران أو فصل.</translation>
+    </message>
+    <message>
+        <source>Association requires one (1) reference.</source>
+        <translation>يتطلب التجميع مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Boolean Dominance Error: Expected absorption with True/False constants.</source>
+        <translation>خطأ هيمنة منطقية: كان من المتوقع امتصاص مع ثوابت صح/خطأ.</translation>
+    </message>
+    <message>
+        <source>Boolean Domination requires one (1) reference.</source>
+        <translation>تتطلب الهيمنة المنطقية مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: Could not align the longer sentence&apos;s structure with the point of difference.</source>
+        <translation>خطأ تطابق منطقي: تعذرت مطابقة بنية الجملة الأطول مع نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: Simplifying or expanding the True/False constant does not produce a sentence matching the other line.</source>
+        <translation>خطأ تطابق منطقي: تبسيط أو توسيع الثابت صح/خطأ لا ينتج جملة تطابق السطر الآخر.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: The difference must be enclosed by a connective, not at the very start of the sentence.</source>
+        <translation>خطأ تطابق منطقي: يجب أن يكون الاختلاف محاطًا برابطة، وليس في بداية الجملة تمامًا.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: The longer sentence must have a connective at the point of difference.</source>
+        <translation>خطأ تطابق منطقي: يجب أن تحتوي الجملة الأطول على رابطة عند نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity requires one (1) reference.</source>
+        <translation>يتطلب التطابق المنطقي مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Boolean Negation Error: Expected complementary cancellation or constant negation.</source>
+        <translation>خطأ نفي منطقي: كان من المتوقع إلغاء تكاملي أو نفي ثابت.</translation>
+    </message>
+    <message>
+        <source>Boolean Negation requires one (1) reference.</source>
+        <translation>يتطلب النفي المنطقي مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Both of the left sentences must be the same.</source>
+        <translation>يجب أن تكون الجملتان اليسريان متطابقتين.</translation>
+    </message>
+    <message>
+        <source>Both sides of the conditional must be negated in the longer sentence.</source>
+        <translation>يجب نفي طرفي الشرطية كليهما في الجملة الأطول.</translation>
+    </message>
+    <message>
+        <source>Bound Variable Substitution constructed incorrectly.</source>
+        <translation>تم بناء استبدال المتغير المقيد بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Bound Variable constructed incorrectly.</source>
+        <translation>تم بناء المتغير المقيد بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Bound Variable requires one (1) reference.</source>
+        <translation>يتطلب المتغير المقيد مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Commutativity constructed incorrectly.</source>
+        <translation>تم بناء التبديل بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Commutativity requires one (1) reference.</source>
+        <translation>يتطلب التبديل مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Conjunction Error: The referenced conjuncts do not match the conclusion.</source>
+        <translation>خطأ اقتران: المقترنات المُشار إليها لا تطابق الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>Conjunction requires at least two (2) references.</source>
+        <translation>يتطلب الاقتران مرجعين (2) على الأقل.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma Error: The antecedents or consequences do not correspond to the conclusion&apos;s disjuncts.</source>
+        <translation>خطأ في المعضلة البناءة: المقدَّمات أو التوالي لا تطابق فواصل الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma Error: The structure of the conditionals or disjunctions does not match.</source>
+        <translation>خطأ في المعضلة البناءة: بنية الشرطيات أو الفواصل لا تتطابق.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma requires at least three (3) references.</source>
+        <translation>تتطلب المعضلة البناءة ثلاثة (3) مراجع على الأقل.</translation>
+    </message>
+    <message>
+        <source>Contrapositive constructed incorrectly.</source>
+        <translation>تم بناء عكس النقيض بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Contrapositive requires one (1) reference.</source>
+        <translation>يتطلب عكس النقيض مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>DeMorgan Error: Expected equivalence when distributing negation across conjunction or disjunction.</source>
+        <translation>خطأ دي مورغان: كان من المتوقع تكافؤ عند توزيع النفي على الاقتران أو الفصل.</translation>
+    </message>
+    <message>
+        <source>DeMorgan Quantifier Error: Expected a quantifier on the negated statement.</source>
+        <translation>خطأ مكمم دي مورغان: كان من المتوقع وجود مكمم على العبارة المنفية.</translation>
+    </message>
+    <message>
+        <source>DeMorgan constructed incorrectly.</source>
+        <translation>تم بناء قانون دي مورغان بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>DeMorgan requires one (1) reference.</source>
+        <translation>يتطلب قانون دي مورغان مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Disjunctive Syllogism Error: The referenced disjunction or negation does not match the conclusion.</source>
+        <translation>خطأ في القياس المنفصل: الفصل أو النفي المُشار إليه لا يطابق الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>Disjunctive Syllogism requires at least two (2) references.</source>
+        <translation>يتطلب القياس المنفصل مرجعين (2) على الأقل.</translation>
+    </message>
+    <message>
+        <source>Distribution Error: A universal quantifier is distributed over a conjunction, and an existential quantifier is distributed over a disjunction.</source>
+        <translation>خطأ توزيع: يُوزَّع المكمم الكلي على اقتران، ويُوزَّع المكمم الوجودي على فصل.</translation>
+    </message>
+    <message>
+        <source>Distribution constructed incorrectly.</source>
+        <translation>تم بناء التوزيع بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Distribution must be done around a conjunction or a disjunction.</source>
+        <translation>يجب أن يتم التوزيع حول اقتران أو فصل.</translation>
+    </message>
+    <message>
+        <source>Distribution requires one (1) reference.</source>
+        <translation>يتطلب التوزيع مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Double Negation constructed incorrectly.</source>
+        <translation>تم بناء النفي المزدوج بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Double Negation must be used to eliminate negations.</source>
+        <translation>يجب استخدام النفي المزدوج لإزالة النفيات.</translation>
+    </message>
+    <message>
+        <source>Double Negation removes negations in pairs.</source>
+        <translation>يزيل النفي المزدوج النفيات في أزواج.</translation>
+    </message>
+    <message>
+        <source>Double Negation requires one (1) reference.</source>
+        <translation>يتطلب النفي المزدوج مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Equivalence constructed incorrectly.</source>
+        <translation>تم بناء التكافؤ بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Equivalence requires one (1) reference.</source>
+        <translation>يتطلب التكافؤ مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Excluded Middle requires zero (0) references.</source>
+        <translation>يتطلب الثالث المرفوع صفر (0) مراجع.</translation>
+    </message>
+    <message>
+        <source>Existential Generalization constructed incorrectly.</source>
+        <translation>تم بناء التعميم الوجودي بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Existential Generalization requires exactly one (1) reference.</source>
+        <translation>يتطلب التعميم الوجودي مرجعًا واحدًا (1) بالضبط.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation Error: The instantiated variable must be completely new and not previously used in the proof.</source>
+        <translation>خطأ تخصيص وجودي: يجب أن يكون المتغير المُخصَّص جديدًا تمامًا وغير مُستخدَم سابقًا في الإثبات.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation constructed incorrectly.</source>
+        <translation>تم بناء التخصيص الوجودي بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation requires exactly one (1) reference.</source>
+        <translation>يتطلب التخصيص الوجودي مرجعًا واحدًا (1) بالضبط.</translation>
+    </message>
+    <message>
+        <source>Exportation constructed incorrectly.</source>
+        <translation>تم بناء التصدير بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Exportation requires one (1) reference.</source>
+        <translation>يتطلب التصدير مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>File Error: Unable to open or read the specified lemma file.</source>
+        <translation>خطأ في الملف: تعذر فتح أو قراءة ملف التمهيدية المحدد.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution Error: Neither premise&apos;s substitution matches the conclusion.</source>
+        <translation>خطأ استبدال متغير حر: لا يطابق استبدال أي من الفرضيتين الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution Error: The substitution does not match the conclusion.</source>
+        <translation>خطأ استبدال متغير حر: الاستبدال لا يطابق الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution requires one or two (1 or 2) references.</source>
+        <translation>يتطلب استبدال المتغير الحر مرجعًا واحدًا أو مرجعين (1 أو 2).</translation>
+    </message>
+    <message>
+        <source>Hypothetical Syllogism requires at least two (2) references.</source>
+        <translation>يتطلب القياس الشرطي مرجعين (2) على الأقل.</translation>
+    </message>
+    <message>
+        <source>Idempotence constructed incorrectly.</source>
+        <translation>تم بناء تساوي القوى بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Idempotence requires one (1) reference.</source>
+        <translation>يتطلب تساوي القوى مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Identity requires zero (0) references.</source>
+        <translation>يتطلب التطابق صفر (0) مراجع.</translation>
+    </message>
+    <message>
+        <source>Implication Error: Expected equivalence between a conditional (P -&gt; Q) and a disjunction (~P v Q).</source>
+        <translation>خطأ استلزام: كان من المتوقع تكافؤ بين شرطية (P -&gt; Q) وفصل (~P v Q).</translation>
+    </message>
+    <message>
+        <source>Implication requires one (1) reference.</source>
+        <translation>يتطلب الاستلزام مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Induction Error: The base case or inductive step does not match the universal conclusion.</source>
+        <translation>خطأ استقراء: الحالة الأساسية أو الخطوة الاستقرائية لا تطابق الاستنتاج الكلي.</translation>
+    </message>
+    <message>
+        <source>Induction requires two (2) references.</source>
+        <translation>يتطلب الاستقراء مرجعين (2).</translation>
+    </message>
+    <message>
+        <source>Internal error: this line could not be evaluated (out of memory).</source>
+        <translation>خطأ داخلي: تعذر تقييم هذا السطر (نفدت الذاكرة).</translation>
+    </message>
+    <message>
+        <source>Invalid Reference: A referenced line has a syntax or evaluation error. First fix the error on that line.</source>
+        <translation>مرجع غير صالح: يحتوي السطر المُشار إليه على خطأ نحوي أو خطأ في التقييم. أصلح الخطأ في ذلك السطر أولًا.</translation>
+    </message>
+    <message>
+        <source>Invalid Reference: One or more referenced line numbers do not exist in this proof.</source>
+        <translation>مرجع غير صالح: رقم سطر مُشار إليه أو أكثر غير موجود في هذا الإثبات.</translation>
+    </message>
+    <message>
+        <source>Lemma Error: The number of references provided must exactly match the number of premises required by the lemma.</source>
+        <translation>خطأ تمهيدية: يجب أن يطابق عدد المراجع المقدَّمة بالضبط عدد الفرضيات التي تتطلبها التمهيدية.</translation>
+    </message>
+    <message>
+        <source>Lemma Error: The referenced lemma does not match the premises or conclusion required by this line.</source>
+        <translation>خطأ تمهيدية: التمهيدية المُشار إليها لا تطابق الفرضيات أو الاستنتاج المطلوبَين لهذا السطر.</translation>
+    </message>
+    <message>
+        <source>Missing Rule: Please select a justification rule for this proof line.</source>
+        <translation>قاعدة مفقودة: يرجى اختيار قاعدة تبرير لسطر الإثبات هذا.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: Neither the antecedent nor the consequence of the conditional matches the premise or conclusion. Check your references and line order.</source>
+        <translation>خطأ في قياس فك الشرط: لا يطابق مقدَّم الشرطية ولا تاليها الفرضية أو الاستنتاج. تحقق من المراجع وترتيب الأسطر.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: One of the references must be a conditional statement (-&gt;).</source>
+        <translation>خطأ في قياس فك الشرط: يجب أن يكون أحد المرجعين جملة شرطية (-&gt;).</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: The antecedent of the conditional (-&gt;) does not match the minor premise reference.</source>
+        <translation>خطأ في قياس فك الشرط: لا يطابق مقدَّم الشرطية (-&gt;) مرجع الفرضية الصغرى.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: The consequence of the conditional (-&gt;) does not match the conclusion.</source>
+        <translation>خطأ في قياس فك الشرط: لا يطابق تالي الشرطية (-&gt;) الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens requires two (2) references.</source>
+        <translation>يتطلب قياس فك الشرط مرجعين (2).</translation>
+    </message>
+    <message>
+        <source>None of the goals from the proof matched up with the conclusion.</source>
+        <translation>لم يطابق أي من أهداف الإثبات الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>None of the references matched one of the proof premises.</source>
+        <translation>لم يطابق أي من المراجع أيًا من فرضيات الإثبات.</translation>
+    </message>
+    <message>
+        <source>Null Quantification requires one (1) reference.</source>
+        <translation>يتطلب التكميم الصفري مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: Could not find a matching connective enclosing the quantifier.</source>
+        <translation>خطأ مكمم صفري: تعذر إيجاد رابطة مطابقة تحيط بالمكمم.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: Removing the quantifier does not produce a sentence matching the other line.</source>
+        <translation>خطأ مكمم صفري: إزالة المكمم لا تنتج جملة تطابق السطر الآخر.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: The point of difference must be a quantifier with no free occurrences of its variable.</source>
+        <translation>خطأ مكمم صفري: يجب أن تكون نقطة الاختلاف مكممًا لا يظهر متغيره بشكل حر.</translation>
+    </message>
+    <message>
+        <source>One of the antecedents did not match a disjunct from the reference.</source>
+        <translation>أحد المقدَّمات لم يطابق أي فاصل من المرجع.</translation>
+    </message>
+    <message>
+        <source>One of the conclusion&apos;s disjuncts did not match a consequence.</source>
+        <translation>أحد فواصل الاستنتاج لم يطابق أي تالٍ.</translation>
+    </message>
+    <message>
+        <source>One of the conjuncts in the conclusion does not match up with a reference.</source>
+        <translation>أحد مقترنات الاستنتاج لا يطابق أي مرجع.</translation>
+    </message>
+    <message>
+        <source>One of the conjuncts in the reference must match the conclusion.</source>
+        <translation>يجب أن يطابق أحد مقترنَي المرجع الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>One of the consequences did not match a disjunct from the conclusion.</source>
+        <translation>أحد التوالي لم يطابق أي فاصل من الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>One of the consequences of a reference does not match an antecedent.</source>
+        <translation>تالي أحد المراجع لا يطابق أي مقدَّم.</translation>
+    </message>
+    <message>
+        <source>One of the disjuncts does not correspond to a reference or the conclusion.</source>
+        <translation>أحد الفواصل لا يطابق أي مرجع ولا الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>One of the premises must contain an identity predicate.</source>
+        <translation>يجب أن تحتوي إحدى الفرضيتين على محمول تطابق.</translation>
+    </message>
+    <message>
+        <source>One of the reference&apos;s disjuncts did not match an antecedent.</source>
+        <translation>أحد فواصل المرجع لم يطابق أي مقدَّم.</translation>
+    </message>
+    <message>
+        <source>One of the references does not match up with a conjunct in the conclusion.</source>
+        <translation>أحد المراجع لا يطابق أي مقترن في الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>One of the references must contain an XOR as its top connective.</source>
+        <translation>يجب أن يحتوي أحد المرجعين على فصل حصري كرابطة عليا.</translation>
+    </message>
+    <message>
+        <source>One of the references or conclusion does not match up with a disjunct.</source>
+        <translation>أحد المراجع أو الاستنتاج لا يطابق أي فاصل.</translation>
+    </message>
+    <message>
+        <source>One sentence must contain a disjunction.</source>
+        <translation>يجب أن تحتوي إحدى الجملتين على فصل.</translation>
+    </message>
+    <message>
+        <source>Only line 1 can be blank; subsequent blank lines are not allowed.</source>
+        <translation>يمكن أن يكون السطر 1 فقط فارغًا؛ لا يُسمح بالأسطر الفارغة التالية.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: Could not find a matching connective enclosing the quantifier.</source>
+        <translation>خطأ صيغة برينكس: تعذر إيجاد رابطة مطابقة تحيط بالمكمم.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: Moving the quantifier does not produce a sentence matching the other line.</source>
+        <translation>خطأ صيغة برينكس: نقل المكمم لا ينتج جملة تطابق السطر الآخر.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: The quantifier must be preceded by a connective for it to be moved.</source>
+        <translation>خطأ صيغة برينكس: يجب أن يسبق المكمم رابطة حتى يمكن نقله.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: The quantifier&apos;s scope must not be empty.</source>
+        <translation>خطأ صيغة برينكس: يجب ألا يكون نطاق المكمم فارغًا.</translation>
+    </message>
+    <message>
+        <source>Prenex requires one (1) reference.</source>
+        <translation>تتطلب صيغة برينكس مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Rule &apos;sp&apos; (Subproof) can only reference the starting line of a subproof.</source>
+        <translation>لا يمكن لقاعدة &apos;sp&apos; (الإثبات الفرعي) أن تشير إلا إلى سطر بداية الإثبات الفرعي.</translation>
+    </message>
+    <message>
+        <source>Rule not recognized.</source>
+        <translation>القاعدة غير معروفة.</translation>
+    </message>
+    <message>
+        <source>Sequence requires zero (0) references.</source>
+        <translation>يتطلب التسلسل صفر (0) مراجع.</translation>
+    </message>
+    <message>
+        <source>Simplification requires one (1) reference.</source>
+        <translation>يتطلب التبسيط مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Subproof Error: The premise of the subproof must match the conditional&apos;s antecedent, and the subproof conclusion must match the consequence.</source>
+        <translation>خطأ إثبات فرعي: يجب أن تطابق فرضية الإثبات الفرعي مقدَّم الشرطية، وأن يطابق استنتاج الإثبات الفرعي التالي.</translation>
+    </message>
+    <message>
+        <source>Subproof Error: The rule &apos;sp&apos; requires a subproof line as a reference.</source>
+        <translation>خطأ إثبات فرعي: تتطلب قاعدة &apos;sp&apos; سطر إثبات فرعي كمرجع.</translation>
+    </message>
+    <message>
+        <source>Subsumption constructed incorrectly.</source>
+        <translation>تم بناء الإدراج بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around a connective.</source>
+        <translation>يجب أن يتم الإدراج حول رابطة.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around a disjunction or a conjunction.</source>
+        <translation>يجب أن يتم الإدراج حول فصل أو اقتران.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around two connectives.</source>
+        <translation>يجب أن يتم الإدراج حول رابطتين.</translation>
+    </message>
+    <message>
+        <source>Subsumption requires one (1) reference.</source>
+        <translation>يتطلب الإدراج مرجعًا واحدًا (1).</translation>
+    </message>
+    <message>
+        <source>Symbol Negation Error: Expected negation of a Boolean constant symbol.</source>
+        <translation>خطأ نفي الرمز: كان من المتوقع نفي رمز ثابت منطقي.</translation>
+    </message>
+    <message>
+        <source>Symbol Negation requires exactly one (1) reference.</source>
+        <translation>يتطلب نفي الرمز مرجعًا واحدًا (1) بالضبط.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Chaining conditionals (-&gt;), biconditionals (&lt;-&gt;), or XOR without enclosing parentheses is ambiguous.</source>
+        <translation>خطأ نحوي: سلسلة من الشرطيات (-&gt;) أو ثنائيات الشرط (&lt;-&gt;) أو الفصل الحصري دون أقواس محيطة أمر ملتبس.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Individual terms and variables must start with a lowercase letter (a-z) or number.</source>
+        <translation>خطأ نحوي: يجب أن تبدأ الحدود الفردية والمتغيرات بحرف صغير (a-z) أو رقم.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Invalid characters in symbol name or empty argument parentheses &apos;()&apos;.</source>
+        <translation>خطأ نحوي: أحرف غير صالحة في اسم الرمز أو أقواس وسيطة فارغة &apos;()&apos;.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Mismatched parentheses. Check opening and closing brackets.</source>
+        <translation>خطأ نحوي: أقواس غير متطابقة. تحقق من الأقواس الافتتاحية والختامية.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Predicate or propositional variable names must start with an uppercase letter (A-Z).</source>
+        <translation>خطأ نحوي: يجب أن تبدأ أسماء المحمولات أو متغيرات القضايا بحرف كبير (A-Z).</translation>
+    </message>
+    <message>
+        <source>Syntax Error: The sentence has syntactical errors.</source>
+        <translation>خطأ نحوي: تحتوي الجملة على أخطاء نحوية.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Unrecognized or invalid logical connective symbol.</source>
+        <translation>خطأ نحوي: رمز رابطة منطقية غير معروف أو غير صالح.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Unrecognized or invalid quantifier symbol.</source>
+        <translation>خطأ نحوي: رمز مكمم غير معروف أو غير صالح.</translation>
+    </message>
+    <message>
+        <source>The conclusion must contain an XOR.</source>
+        <translation>يجب أن يحتوي الاستنتاج على فصل حصري.</translation>
+    </message>
+    <message>
+        <source>The conclusion must have an identity predicate.</source>
+        <translation>يجب أن يحتوي الاستنتاج على محمول تطابق.</translation>
+    </message>
+    <message>
+        <source>The conclusion must start with a universal.</source>
+        <translation>يجب أن يبدأ الاستنتاج بمكمم كلي.</translation>
+    </message>
+    <message>
+        <source>The connective must be a conjunction or disjunction.</source>
+        <translation>يجب أن تكون الرابطة اقترانًا أو فصلًا.</translation>
+    </message>
+    <message>
+        <source>The difference must be a bound variable.</source>
+        <translation>يجب أن يكون الاختلاف متغيرًا مقيدًا.</translation>
+    </message>
+    <message>
+        <source>The difference must be a quantifier.</source>
+        <translation>يجب أن يكون الاختلاف مكممًا.</translation>
+    </message>
+    <message>
+        <source>The final argument of the sequence&apos;s function must be the variable.</source>
+        <translation>يجب أن يكون الوسيط الأخير لدالة التسلسل هو المتغير.</translation>
+    </message>
+    <message>
+        <source>The first argument must be a value function.</source>
+        <translation>يجب أن يكون الوسيط الأول دالة قيمة.</translation>
+    </message>
+    <message>
+        <source>The left disjunct must be the negation of the right disjunct.</source>
+        <translation>يجب أن يكون الفاصل الأيسر نفيًا للفاصل الأيمن.</translation>
+    </message>
+    <message>
+        <source>The left disjunct must have a negation.</source>
+        <translation>يجب أن يحتوي الفاصل الأيسر على نفي.</translation>
+    </message>
+    <message>
+        <source>The minor premise and conclusion do not match the XOR disjuncts correctly.</source>
+        <translation>الفرضية الصغرى والاستنتاج لا يطابقان فاصلَي الفصل الحصري بشكل صحيح.</translation>
+    </message>
+    <message>
+        <source>The negation sentence must be negating either a conjunction or a disjunction.</source>
+        <translation>يجب أن تنفي جملة النفي إما اقترانًا أو فصلًا.</translation>
+    </message>
+    <message>
+        <source>The new variable did not appear in the conclusion.</source>
+        <translation>لم يظهر المتغير الجديد في الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>The quantifiers must be the same.</source>
+        <translation>يجب أن تكون المكممات متطابقة.</translation>
+    </message>
+    <message>
+        <source>The reference must be the first disjunct in the conclusion.</source>
+        <translation>يجب أن يكون المرجع هو الفاصل الأول في الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>The rest of the sentences must be the same.</source>
+        <translation>يجب أن يتطابق بقية الجملتين.</translation>
+    </message>
+    <message>
+        <source>The second part must be the negation of the first.</source>
+        <translation>يجب أن يكون الجزء الثاني نفيًا للجزء الأول.</translation>
+    </message>
+    <message>
+        <source>The sequence must only be used once.</source>
+        <translation>يجب استخدام التسلسل مرة واحدة فقط.</translation>
+    </message>
+    <message>
+        <source>The sequence variable must not have been used before.</source>
+        <translation>يجب ألا يكون متغير التسلسل قد استُخدم من قبل.</translation>
+    </message>
+    <message>
+        <source>The top connective must change between sentences.</source>
+        <translation>يجب أن تتغير الرابطة العليا بين الجملتين.</translation>
+    </message>
+    <message>
+        <source>The two arguments to the identity predicate must be the same.</source>
+        <translation>يجب أن يتطابق وسيطا محمول التطابق.</translation>
+    </message>
+    <message>
+        <source>The two connectives must be complementary to one another.</source>
+        <translation>يجب أن تكون الرابطتان متكاملتين مع بعضهما.</translation>
+    </message>
+    <message>
+        <source>The two references must match the two disjuncts of the XOR conclusion.</source>
+        <translation>يجب أن يطابق المرجعان فاصلَي استنتاج الفصل الحصري.</translation>
+    </message>
+    <message>
+        <source>The two sentences must be of different lengths.</source>
+        <translation>يجب أن تكون الجملتان بطولين مختلفين.</translation>
+    </message>
+    <message>
+        <source>The variable must be the second argument of the value function.</source>
+        <translation>يجب أن يكون المتغير هو الوسيط الثاني لدالة القيمة.</translation>
+    </message>
+    <message>
+        <source>The variable must be used only twice.</source>
+        <translation>يجب استخدام المتغير مرتين فقط.</translation>
+    </message>
+    <message>
+        <source>The variables must not appear in the scope.</source>
+        <translation>يجب ألا تظهر المتغيرات ضمن النطاق.</translation>
+    </message>
+    <message>
+        <source>There must be a biconditional in one sentence.</source>
+        <translation>يجب أن تحتوي إحدى الجملتين على ثنائي الشرط.</translation>
+    </message>
+    <message>
+        <source>There must be a conditional in both sentences.</source>
+        <translation>يجب أن تحتوي الجملتان كلتاهما على شرطية.</translation>
+    </message>
+    <message>
+        <source>There must be a conditional in the conclusion.</source>
+        <translation>يجب أن يحتوي الاستنتاج على شرطية.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction in the conclusion.</source>
+        <translation>يجب أن يحتوي الاستنتاج على اقتران.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction in the reference.</source>
+        <translation>يجب أن يحتوي المرجع على اقتران.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction or a disjunction at the difference.</source>
+        <translation>يجب أن يكون هناك اقتران أو فصل عند نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction or a disjunction in one sentence.</source>
+        <translation>يجب أن تحتوي إحدى الجملتين على اقتران أو فصل.</translation>
+    </message>
+    <message>
+        <source>There must be a connective at the difference.</source>
+        <translation>يجب أن تكون هناك رابطة عند نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in both sentences.</source>
+        <translation>يجب أن تحتوي الجملتان كلتاهما على رابطة.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in one sentence.</source>
+        <translation>يجب أن تحتوي إحدى الجملتين على رابطة.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in the longer sentence.</source>
+        <translation>يجب أن تحتوي الجملة الأطول على رابطة.</translation>
+    </message>
+    <message>
+        <source>There must be a disjunction in the conclusion.</source>
+        <translation>يجب أن يحتوي الاستنتاج على فصل.</translation>
+    </message>
+    <message>
+        <source>There must be a disjunction in the longest reference.</source>
+        <translation>يجب أن يحتوي أطول مرجع على فصل.</translation>
+    </message>
+    <message>
+        <source>There must be a negated symbol in one sentence.</source>
+        <translation>يجب أن تحتوي إحدى الجملتين على رمز منفي.</translation>
+    </message>
+    <message>
+        <source>There must be a negation at the difference.</source>
+        <translation>يجب أن يكون هناك نفي عند نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>There must be a negation in one sentence.</source>
+        <translation>يجب أن تحتوي إحدى الجملتين على نفي.</translation>
+    </message>
+    <message>
+        <source>There must be a quantifier after the negation.</source>
+        <translation>يجب أن يكون هناك مكمم بعد النفي.</translation>
+    </message>
+    <message>
+        <source>There must be a quantifier at the difference.</source>
+        <translation>يجب أن يكون هناك مكمم عند نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>There must be a tautology or a contradiction in the generalities.</source>
+        <translation>يجب أن يكون هناك تناقض منطقي (تحصيل حاصل) أو تناقض ضمن العموميات.</translation>
+    </message>
+    <message>
+        <source>There must be a tautology or a contradiction within the difference.</source>
+        <translation>يجب أن يكون هناك تحصيل حاصل أو تناقض ضمن نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>There must be a universal at the beginning of the conclusion.</source>
+        <translation>يجب أن يكون هناك مكمم كلي في بداية الاستنتاج.</translation>
+    </message>
+    <message>
+        <source>There must be an identity predicate in the scope.</source>
+        <translation>يجب أن يكون هناك محمول تطابق ضمن النطاق.</translation>
+    </message>
+    <message>
+        <source>There must be connectives on both sentences.</source>
+        <translation>يجب أن تحتوي الجملتان كلتاهما على روابط.</translation>
+    </message>
+    <message>
+        <source>There must be generalities at the difference.</source>
+        <translation>يجب أن تكون هناك عموميات عند نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>There must be generalities in the scope.</source>
+        <translation>يجب أن تكون هناك عموميات ضمن النطاق.</translation>
+    </message>
+    <message>
+        <source>There must be more than one generality for distribution.</source>
+        <translation>يجب أن يكون هناك أكثر من عمومية واحدة للتوزيع.</translation>
+    </message>
+    <message>
+        <source>There must be only two connected parts.</source>
+        <translation>يجب أن يكون هناك جزآن مترابطان فقط.</translation>
+    </message>
+    <message>
+        <source>There must be only two parts for distribution.</source>
+        <translation>يجب أن يكون هناك جزآن فقط للتوزيع.</translation>
+    </message>
+    <message>
+        <source>There must be quantifiers at the difference.</source>
+        <translation>يجب أن تكون هناك مكممات عند نقطة الاختلاف.</translation>
+    </message>
+    <message>
+        <source>Universal Generalization Error: The generalized variable must be arbitrary (not introduced by Existential Instantiation or unclosed assumptions).</source>
+        <translation>خطأ تعميم كلي: يجب أن يكون المتغير المُعمَّم عشوائيًا (غير مُستحدَث بواسطة تخصيص وجودي أو افتراضات غير مغلقة).</translation>
+    </message>
+    <message>
+        <source>Universal Generalization constructed incorrectly.</source>
+        <translation>تم بناء التعميم الكلي بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Universal Generalization requires exactly one (1) reference.</source>
+        <translation>يتطلب التعميم الكلي مرجعًا واحدًا (1) بالضبط.</translation>
+    </message>
+    <message>
+        <source>Universal Instantiation constructed incorrectly.</source>
+        <translation>تم بناء التخصيص الكلي بشكل غير صحيح.</translation>
+    </message>
+    <message>
+        <source>Universal Instantiation requires exactly one (1) reference.</source>
+        <translation>يتطلب التخصيص الكلي مرجعًا واحدًا (1) بالضبط.</translation>
+    </message>
+    <message>
+        <source>XOR Elimination requires exactly two (2) references.</source>
+        <translation>تتطلب إزالة الفصل الحصري مرجعين (2) بالضبط.</translation>
+    </message>
+    <message>
+        <source>XOR Introduction requires exactly two (2) references.</source>
+        <translation>يتطلب إدخال الفصل الحصري مرجعين (2) بالضبط.</translation>
+    </message>
 </context>
 </TS>

--- a/qt/i18n/aris-qt_de.ts
+++ b/qt/i18n/aris-qt_de.ts
@@ -2,54 +2,33 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="de_DE" sourcelanguage="en_US">
 <context>
-    <name>KeyGroup</name>
+    <name>Connector</name>
     <message>
-        <source>Conjunction</source>
-        <translation>Konjunktion</translation>
+        <location filename="../connector.cpp" line="415"/>
+        <source>Line %1 · %2: %3</source>
+        <translation>Zeile %1 · %2: %3</translation>
     </message>
     <message>
-        <source>Disjunction</source>
-        <translation>Disjunktion</translation>
+        <location filename="../connector.cpp" line="481"/>
+        <source>File save failed for path: %1</source>
+        <translation>Speichern der Datei unter %1 fehlgeschlagen</translation>
     </message>
     <message>
-        <source>Negation</source>
-        <translation>Negation</translation>
+        <location filename="../connector.cpp" line="514"/>
+        <source>File open failed for path: %1</source>
+        <translation>Öffnen der Datei unter %1 fehlgeschlagen</translation>
     </message>
     <message>
-        <source>Implication</source>
-        <translation>Implikation</translation>
+        <source>Evaluate Proof</source>
+        <translation>Beweis auswerten</translation>
     </message>
     <message>
-        <source>Bi-conditional</source>
-        <translation>Bikonditional</translation>
+        <source>Correct!</source>
+        <translation>Korrekt!</translation>
     </message>
     <message>
-        <source>For all</source>
-        <translation>Für alle</translation>
-    </message>
-    <message>
-        <source>There exists</source>
-        <translation>Es existiert</translation>
-    </message>
-    <message>
-        <source>Tautology</source>
-        <translation>Tautologie</translation>
-    </message>
-    <message>
-        <source>Contradiction</source>
-        <translation>Widerspruch</translation>
-    </message>
-    <message>
-        <source>Belongs To</source>
-        <translation>Gehört zu</translation>
-    </message>
-    <message>
-        <source>Null</source>
-        <translation>Null</translation>
-    </message>
-    <message>
-        <source>XOR</source>
-        <translation>XOR</translation>
+        <source>Errors found</source>
+        <translation>Fehler gefunden</translation>
     </message>
 </context>
 <context>
@@ -70,381 +49,1469 @@
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="78"/>
+        <location filename="../DrawerTools.qml" line="77"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="97"/>
+        <location filename="../DrawerTools.qml" line="96"/>
         <source>Save As</source>
         <translation>Speichern unter</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="114"/>
         <source>Export To LaTeX</source>
-        <translation>Nach LaTeX exportieren</translation>
+        <translation type="vanished">Nach LaTeX exportieren</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="133"/>
+        <location filename="../DrawerTools.qml" line="107"/>
+        <source>Export</source>
+        <translation>Exportieren</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="122"/>
         <source>Toggle Goals</source>
         <translation>Ziele umschalten</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="147"/>
+        <location filename="../DrawerTools.qml" line="136"/>
         <source>Toggle Dark Mode</source>
         <translation>Dunkelmodus umschalten</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="175"/>
+        <location filename="../DrawerTools.qml" line="164"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="224"/>
+        <location filename="../DrawerTools.qml" line="213"/>
         <source>Reset Zoom</source>
         <translation>Zoom zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="231"/>
+        <location filename="../DrawerTools.qml" line="220"/>
         <source>Paste Proof from Clipboard</source>
         <translation>Beweis aus Zwischenablage einfügen</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="237"/>
+        <location filename="../DrawerTools.qml" line="226"/>
         <source>(Ctrl+Shift+V)</source>
         <translation>(Strg+Umschalt+V)</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="246"/>
+        <location filename="../DrawerTools.qml" line="235"/>
         <source>Copy Selected Lines</source>
         <translation>Ausgewählte Zeilen kopieren</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="252"/>
+        <location filename="../DrawerTools.qml" line="241"/>
         <source>(Ctrl+Shift+C)</source>
         <translation>(Strg+Umschalt+C)</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="261"/>
+        <location filename="../DrawerTools.qml" line="250"/>
         <source>Import Proof</source>
         <translation>Beweis importieren</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="273"/>
+        <location filename="../DrawerTools.qml" line="262"/>
         <source>Font</source>
         <translation>Schriftart</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="283"/>
+        <location filename="../DrawerTools.qml" line="272"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="314"/>
+        <location filename="../DrawerTools.qml" line="315"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="322"/>
+        <location filename="../DrawerTools.qml" line="323"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Beweis auswerten</translation>
+    </message>
 </context>
 <context>
-    <name>main</name>
+    <name>GoalLine</name>
     <message>
-        <location filename="../main.qml" line="145"/>
-        <source>QT_LAYOUT_DIRECTION</source>
-        <comment>QGuiApplication</comment>
-        <translation>LTR</translation>
+        <location filename="../GoalLine.qml" line="163"/>
+        <source>Invalid Operation: At least one goal line must remain.</source>
+        <translation>Ungültige Operation: Mindestens eine Zielzeile muss erhalten bleiben.</translation>
+    </message>
+</context>
+<context>
+    <name>KeyGroup</name>
+    <message>
+        <location filename="../KeyGroup.qml" line="37"/>
+        <source>Conjunction</source>
+        <translation>Konjunktion</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="354"/>
-        <source>Unsaved changes</source>
-        <translation>Nicht gespeicherte Änderungen</translation>
+        <location filename="../KeyGroup.qml" line="44"/>
+        <source>Disjunction</source>
+        <translation>Disjunktion</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
-        <source>Save file before closing?</source>
-        <translation>Datei vor dem Schließen speichern?</translation>
+        <location filename="../KeyGroup.qml" line="51"/>
+        <source>Negation</source>
+        <translation>Negation</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="383"/>
-        <source>Save new file before closing?</source>
-        <translation>Neue Datei vor dem Schließen speichern?</translation>
+        <location filename="../KeyGroup.qml" line="58"/>
+        <source>Implication</source>
+        <translation>Implikation</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="417"/>
-        <source>Reset the current proof and goals?</source>
-        <translation>Aktuellen Beweis und Ziele zurücksetzen?</translation>
+        <location filename="../KeyGroup.qml" line="65"/>
+        <source>Bi-conditional</source>
+        <translation>Bikonditional</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="426"/>
-        <source>Cancel</source>
-        <translation>Abbrechen</translation>
+        <location filename="../KeyGroup.qml" line="72"/>
+        <source>For all</source>
+        <translation>Für alle</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
-        <source>Reset</source>
-        <translation>Zurücksetzen</translation>
+        <location filename="../KeyGroup.qml" line="79"/>
+        <source>There exists</source>
+        <translation>Es existiert</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="485"/>
-        <source>Choose import behavior</source>
-        <translation>Importverhalten auswählen</translation>
+        <location filename="../KeyGroup.qml" line="86"/>
+        <source>Tautology</source>
+        <translation>Tautologie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="494"/>
-        <source>Overwrite</source>
-        <translation>Überschreiben</translation>
+        <location filename="../KeyGroup.qml" line="93"/>
+        <source>Contradiction</source>
+        <translation>Widerspruch</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="506"/>
-        <source>Append End</source>
-        <translation>Am Ende einfügen</translation>
+        <location filename="../KeyGroup.qml" line="100"/>
+        <source>Belongs To</source>
+        <translation>Gehört zu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
-        <source>Prepend</source>
-        <translation>Vorne einfügen</translation>
+        <location filename="../KeyGroup.qml" line="107"/>
+        <source>Null</source>
+        <translation>Null</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="114"/>
+        <source>XOR</source>
+        <translation>XOR</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Beweis auswerten</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>Korrekt!</translation>
     </message>
 </context>
 <context>
     <name>ProofArea</name>
     <message>
-        <location filename="../ProofArea.qml" line="294"/>
+        <location filename="../ProofArea.qml" line="606"/>
         <source>Confirm Conversion</source>
         <translation>Konvertierung bestätigen</translation>
     </message>
     <message>
-        <location filename="../ProofArea.qml" line="311"/>
+        <location filename="../ProofArea.qml" line="623"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../ProofArea.qml" line="323"/>
+        <location filename="../ProofArea.qml" line="635"/>
         <source>Convert Anyway</source>
         <translation>Trotzdem konvertieren</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="439"/>
         <source>Convert</source>
         <translation>Konvertieren</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="226"/>
+        <location filename="../ProofArea.qml" line="261"/>
+        <location filename="../ProofArea.qml" line="285"/>
+        <location filename="../ProofArea.qml" line="313"/>
+        <location filename="../ProofArea.qml" line="353"/>
+        <source>No line selected.</source>
+        <translation>Keine Zeile ausgewählt.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="362"/>
+        <source>Cannot convert structural subproof lines.</source>
+        <translation>Strukturelle Teilbeweiszeilen können nicht umgewandelt werden.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="369"/>
+        <source>Proof must contain at least one premise.</source>
+        <translation>Der Beweis muss mindestens eine Prämisse enthalten.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="441"/>
+        <location filename="../ProofArea.qml" line="1448"/>
         <source>Convert to Conclusion</source>
         <translation>In Schlussfolgerung umwandeln</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="441"/>
+        <location filename="../ProofArea.qml" line="1448"/>
         <source>Convert to Premise</source>
         <translation>In Prämisse umwandeln</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="480"/>
         <source>Add Premise Above</source>
         <translation>Prämisse darüber einfügen</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="498"/>
         <source>Add Conclusion Below</source>
         <translation>Schlussfolgerung darunter einfügen</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="517"/>
+        <source>Add Comment Below</source>
+        <translation>Kommentar darunter hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="869"/>
+        <source>Expand subproof</source>
+        <translation>Teilbeweis erweitern</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="869"/>
+        <source>Collapse subproof</source>
+        <translation>Teilbeweis einklappen</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="901"/>
+        <source>Invalid Operation: A proof line can only reference earlier line numbers.</source>
+        <translation>Ungültige Operation: Eine Beweiszeile kann nur auf frühere Zeilennummern verweisen.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="906"/>
+        <source>Invalid Operation: Cannot assign inference rules or references to a premise.</source>
+        <translation>Ungültige Operation: Schlussregeln oder Referenzen können einer Prämisse nicht zugewiesen werden.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="912"/>
+        <source>Invalid Operation: Cannot modify or reference the start line of a subproof directly.</source>
+        <translation>Ungültige Operation: Die Startzeile eines Teilbeweises kann nicht direkt geändert oder referenziert werden.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="919"/>
+        <source>Invalid Operation: Cannot reference lines across closed subproof boundaries.</source>
+        <translation>Ungültige Operation: Zeilen können nicht über geschlossene Teilbeweisgrenzen hinweg referenziert werden.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1404"/>
         <source>Add Premise</source>
         <translation>Prämisse hinzufügen</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1418"/>
         <source>Add Conclusion</source>
         <translation>Schlussfolgerung hinzufügen</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1434"/>
+        <source>Add Comment</source>
+        <translation>Kommentar hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1484"/>
         <source>Start Subproof</source>
         <translation>Teilbeweis beginnen</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1498"/>
         <source>End Subproof</source>
         <translation>Teilbeweis beenden</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1516"/>
         <source>Remove this Line</source>
         <translation>Diese Zeile entfernen</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1172"/>
         <source>premise</source>
         <translation>Prämisse</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1173"/>
         <source>subproof</source>
         <translation>Teilbeweis</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1174"/>
         <source>sf</source>
         <translation>TBA</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
         <source>Inference</source>
         <translation>Schlussfolgerung</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Equivalence</source>
         <translation>Äquivalenz</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
         <source>Predicate</source>
         <translation>Prädikat</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
         <source>Miscellaneous</source>
         <translation>Sonstiges</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
         <source>Boolean</source>
         <translation>Boolesch</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Modus Ponens</source>
         <translation>Modus Ponens</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Addition</source>
         <translation>Addition</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Simplification</source>
         <translation>Vereinfachung</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Conjunction</source>
         <translation>Konjunktion</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Hypothetical Syllogism</source>
         <translation>Hypothetischer Syllogismus</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Disjunctive Syllogism</source>
         <translation>Disjunktiver Syllogismus</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Excluded middle</source>
         <translation>Satz vom ausgeschlossenen Dritten</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Constructive Dilemma</source>
         <translation>Konstruktives Dilemma</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>XOR Introduction</source>
         <translation>XOR-Einführung</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>XOR Elimination</source>
         <translation>XOR-Elimination</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Implication</source>
         <translation>Implikation</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>DeMorgan</source>
         <translation>De Morgan</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Association</source>
         <translation>Assoziation</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Commutativity</source>
         <translation>Kommutativität</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Idempotence</source>
         <translation>Idempotenz</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Distribution</source>
         <translation>Distribution</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Double Negation</source>
         <translation>Doppelte Verneinung</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Exportation</source>
         <translation>Exportation</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Subsumption</source>
         <translation>Subsumtion</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Contrapositive</source>
         <translation>Kontraposition</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Universal Generalization</source>
         <translation>Universelle Generalisierung</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Universal Instantiation</source>
         <translation>Universelle Instanziierung</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Existential Generalization</source>
         <translation>Existenzielle Generalisierung</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Existential Instantiation</source>
         <translation>Existenzielle Instanziierung</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Bound Variable Substitution</source>
         <translation>Substitution gebundener Variablen</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Null Quantifier</source>
         <translation>Nullquantor</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Prenex</source>
         <translation>Pränex</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Identity</source>
         <translation>Identität</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Free Variable Substitution</source>
         <translation>Substitution freier Variablen</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="122"/>
         <source>Lemma</source>
         <translation>Lemma</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="122"/>
         <source>Subproof</source>
         <translation>Teilbeweis</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="122"/>
         <source>Sequence</source>
         <translation>Folge</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="122"/>
         <source>Induction</source>
         <translation>Induktion</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="123"/>
         <source>Identity </source>
         <translation>Identität </translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="123"/>
         <source>Negation</source>
         <translation>Negation</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="123"/>
         <source>Dominance</source>
         <translation>Dominanz</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="123"/>
         <source>Symbol Negation</source>
         <translation>Symbolnegation</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Beweis auswerten</translation>
+    </message>
+</context>
+<context>
+    <name>auxConnector</name>
+    <message>
+        <location filename="../auxconnector.cpp" line="122"/>
+        <source>LaTeX export failed: could not convert proof to LaTeX format.</source>
+        <translation>LaTeX-Export fehlgeschlagen: Der Beweis konnte nicht in das LaTeX-Format umgewandelt werden.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="165"/>
+        <source>Import failed: the selected file could not be opened or is not a valid Aris proof.</source>
+        <translation>Import fehlgeschlagen: Die ausgewählte Datei konnte nicht geöffnet werden oder ist kein gültiger Aris-Beweis.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="481"/>
+        <source>Text export failed: could not open &apos;%1&apos; for writing.</source>
+        <translation>Textexport fehlgeschlagen: „%1“ konnte nicht zum Schreiben geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="551"/>
+        <source>Markdown export failed: could not open &apos;%1&apos; for writing.</source>
+        <translation>Markdown-Export fehlgeschlagen: „%1“ konnte nicht zum Schreiben geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="855"/>
+        <source>ODT export failed: could not write to &apos;%1&apos;.</source>
+        <translation>ODT-Export fehlgeschlagen: Schreiben nach „%1“ nicht möglich.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="896"/>
+        <source>PDF export is not available on your device.</source>
+        <translation>PDF-Export ist auf diesem Gerät nicht verfügbar.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="915"/>
+        <source>PDF export failed: could not write to &apos;%1&apos;.</source>
+        <translation>PDF-Export fehlgeschlagen: Schreiben nach „%1“ nicht möglich.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="933"/>
+        <source>PDF export is not available in the browser version.</source>
+        <translation>PDF-Export ist in der Browser-Version nicht verfügbar.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../main.qml" line="166"/>
+        <source>Got it</source>
+        <translation>Verstanden</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="201"/>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>QGuiApplication</comment>
+        <translation>LTR</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="563"/>
+        <source>Unsaved changes</source>
+        <translation>Nicht gespeicherte Änderungen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="593"/>
+        <source>Save file before closing?</source>
+        <translation>Datei vor dem Schließen speichern?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
+        <source>Save new file before closing?</source>
+        <translation>Neue Datei vor dem Schließen speichern?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="628"/>
+        <source>Reset the current proof and goals?</source>
+        <translation>Aktuellen Beweis und Ziele zurücksetzen?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="637"/>
+        <location filename="../main.qml" line="1093"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="649"/>
+        <source>Reset</source>
+        <translation>Zurücksetzen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="696"/>
+        <source>Choose import behavior</source>
+        <translation>Importverhalten auswählen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="705"/>
+        <source>Overwrite</source>
+        <translation>Überschreiben</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="717"/>
+        <source>Append End</source>
+        <translation>Am Ende einfügen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="729"/>
+        <source>Prepend</source>
+        <translation>Vorne einfügen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="774"/>
+        <source>Choose export format</source>
+        <translation>Exportformat auswählen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="783"/>
+        <source>LaTeX</source>
+        <translation>LaTeX</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="799"/>
+        <source>Plain Text</source>
+        <translation>Reiner Text</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="815"/>
+        <source>Markdown</source>
+        <translation>Markdown</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="869"/>
+        <source>Choose save format</source>
+        <translation>Speicherformat auswählen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="881"/>
+        <source>Aris (.tle)</source>
+        <translation>Aris (.tle)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="904"/>
+        <source>ODT (.odt)</source>
+        <translation>ODT (.odt)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="926"/>
+        <source>PDF (.pdf)</source>
+        <translation>PDF (.pdf)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1014"/>
+        <source>Jump to Line</source>
+        <translation>Zu Zeile springen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1026"/>
+        <source>Invalid line number. Must be between 1 and </source>
+        <translation>Ungültige Zeilennummer. Muss zwischen 1 und </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1054"/>
+        <source>Line number</source>
+        <translation>Zeilennummer</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1103"/>
+        <source>Jump</source>
+        <translation>Springen</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Beweis auswerten</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>Korrekt!</translation>
+    </message>
+    <message>
+        <source>Errors found</source>
+        <translation>Fehler gefunden</translation>
+    </message>
+    <message>
+        <source>Errors found — see inline details above each failing line.</source>
+        <translation>Fehler gefunden – Details siehe direkt über der jeweils fehlerhaften Zeile.</translation>
+    </message>
+</context>
+<context>
+    <name>ProofErrors</name>
+    <message>
+        <source>A proof must be specified.</source>
+        <translation>Ein Beweis muss angegeben werden.</translation>
+    </message>
+    <message>
+        <source>A tautology must be matched with a conjunction, and a contradiction with a disjunction.</source>
+        <translation>Eine Tautologie muss mit einer Konjunktion und ein Widerspruch mit einer Disjunktion übereinstimmen.</translation>
+    </message>
+    <message>
+        <source>Addition requires one (1) reference.</source>
+        <translation>Addition erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>All of the references except the disjunction reference must contain a conditional.</source>
+        <translation>Alle Referenzen außer der Disjunktionsreferenz müssen ein Konditional enthalten.</translation>
+    </message>
+    <message>
+        <source>All of the references must be used.</source>
+        <translation>Alle Referenzen müssen verwendet werden.</translation>
+    </message>
+    <message>
+        <source>All of the references must contain a conditional.</source>
+        <translation>Alle Referenzen müssen ein Konditional enthalten.</translation>
+    </message>
+    <message>
+        <source>Association constructed incorrectly.</source>
+        <translation>Assoziation falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Association must be done on a conjunction or disjunction.</source>
+        <translation>Assoziation muss auf einer Konjunktion oder Disjunktion durchgeführt werden.</translation>
+    </message>
+    <message>
+        <source>Association requires one (1) reference.</source>
+        <translation>Assoziation erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Boolean Dominance Error: Expected absorption with True/False constants.</source>
+        <translation>Fehler bei der booleschen Dominanz: Es wurde eine Absorption mit den Konstanten Wahr/Falsch erwartet.</translation>
+    </message>
+    <message>
+        <source>Boolean Domination requires one (1) reference.</source>
+        <translation>Boolesche Dominanz erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: Could not align the longer sentence&apos;s structure with the point of difference.</source>
+        <translation>Fehler bei der booleschen Identität: Die Struktur des längeren Satzes konnte nicht mit der Differenzstelle in Übereinstimmung gebracht werden.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: Simplifying or expanding the True/False constant does not produce a sentence matching the other line.</source>
+        <translation>Fehler bei der booleschen Identität: Das Vereinfachen oder Erweitern der Konstante Wahr/Falsch ergibt keinen Satz, der mit der anderen Zeile übereinstimmt.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: The difference must be enclosed by a connective, not at the very start of the sentence.</source>
+        <translation>Fehler bei der booleschen Identität: Die Differenzstelle muss von einer Verknüpfung umschlossen sein und darf nicht ganz am Satzanfang stehen.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: The longer sentence must have a connective at the point of difference.</source>
+        <translation>Fehler bei der booleschen Identität: Der längere Satz muss an der Differenzstelle eine Verknüpfung aufweisen.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity requires one (1) reference.</source>
+        <translation>Boolesche Identität erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Boolean Negation Error: Expected complementary cancellation or constant negation.</source>
+        <translation>Fehler bei der booleschen Negation: Es wurde eine komplementäre Auslöschung oder eine Konstantennegation erwartet.</translation>
+    </message>
+    <message>
+        <source>Boolean Negation requires one (1) reference.</source>
+        <translation>Boolesche Negation erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Both of the left sentences must be the same.</source>
+        <translation>Beide linken Sätze müssen identisch sein.</translation>
+    </message>
+    <message>
+        <source>Both sides of the conditional must be negated in the longer sentence.</source>
+        <translation>Im längeren Satz müssen beide Seiten des Konditionals negiert sein.</translation>
+    </message>
+    <message>
+        <source>Bound Variable Substitution constructed incorrectly.</source>
+        <translation>Substitution gebundener Variablen falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Bound Variable constructed incorrectly.</source>
+        <translation>Gebundene Variable falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Bound Variable requires one (1) reference.</source>
+        <translation>Gebundene Variable erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Commutativity constructed incorrectly.</source>
+        <translation>Kommutativität falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Commutativity requires one (1) reference.</source>
+        <translation>Kommutativität erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Conjunction Error: The referenced conjuncts do not match the conclusion.</source>
+        <translation>Konjunktionsfehler: Die referenzierten Konjunkte stimmen nicht mit der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>Conjunction requires at least two (2) references.</source>
+        <translation>Konjunktion erfordert mindestens zwei (2) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma Error: The antecedents or consequences do not correspond to the conclusion&apos;s disjuncts.</source>
+        <translation>Fehler beim konstruktiven Dilemma: Die Antezedentien oder Konsequentien entsprechen nicht den Disjunkten der Konklusion.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma Error: The structure of the conditionals or disjunctions does not match.</source>
+        <translation>Fehler beim konstruktiven Dilemma: Die Struktur der Konditionale oder Disjunktionen stimmt nicht überein.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma requires at least three (3) references.</source>
+        <translation>Konstruktives Dilemma erfordert mindestens drei (3) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Contrapositive constructed incorrectly.</source>
+        <translation>Kontraposition falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Contrapositive requires one (1) reference.</source>
+        <translation>Kontraposition erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>DeMorgan Error: Expected equivalence when distributing negation across conjunction or disjunction.</source>
+        <translation>De-Morgan-Fehler: Beim Verteilen der Negation über Konjunktion oder Disjunktion wurde eine Äquivalenz erwartet.</translation>
+    </message>
+    <message>
+        <source>DeMorgan Quantifier Error: Expected a quantifier on the negated statement.</source>
+        <translation>De-Morgan-Quantorenfehler: Bei der negierten Aussage wurde ein Quantor erwartet.</translation>
+    </message>
+    <message>
+        <source>DeMorgan constructed incorrectly.</source>
+        <translation>De Morgan falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>DeMorgan requires one (1) reference.</source>
+        <translation>De Morgan erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Disjunctive Syllogism Error: The referenced disjunction or negation does not match the conclusion.</source>
+        <translation>Fehler beim disjunktiven Syllogismus: Die referenzierte Disjunktion oder Negation stimmt nicht mit der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>Disjunctive Syllogism requires at least two (2) references.</source>
+        <translation>Disjunktiver Syllogismus erfordert mindestens zwei (2) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Distribution Error: A universal quantifier is distributed over a conjunction, and an existential quantifier is distributed over a disjunction.</source>
+        <translation>Distributionsfehler: Ein Allquantor wird über eine Konjunktion verteilt, ein Existenzquantor über eine Disjunktion.</translation>
+    </message>
+    <message>
+        <source>Distribution constructed incorrectly.</source>
+        <translation>Distribution falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Distribution must be done around a conjunction or a disjunction.</source>
+        <translation>Distribution muss um eine Konjunktion oder eine Disjunktion herum durchgeführt werden.</translation>
+    </message>
+    <message>
+        <source>Distribution requires one (1) reference.</source>
+        <translation>Distribution erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Double Negation constructed incorrectly.</source>
+        <translation>Doppelte Verneinung falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Double Negation must be used to eliminate negations.</source>
+        <translation>Doppelte Verneinung muss verwendet werden, um Negationen zu eliminieren.</translation>
+    </message>
+    <message>
+        <source>Double Negation removes negations in pairs.</source>
+        <translation>Doppelte Verneinung entfernt Negationen paarweise.</translation>
+    </message>
+    <message>
+        <source>Double Negation requires one (1) reference.</source>
+        <translation>Doppelte Verneinung erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Equivalence constructed incorrectly.</source>
+        <translation>Äquivalenz falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Equivalence requires one (1) reference.</source>
+        <translation>Äquivalenz erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Excluded Middle requires zero (0) references.</source>
+        <translation>Satz vom ausgeschlossenen Dritten erfordert null (0) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Existential Generalization constructed incorrectly.</source>
+        <translation>Existenzielle Generalisierung falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Existential Generalization requires exactly one (1) reference.</source>
+        <translation>Existenzielle Generalisierung erfordert genau eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation Error: The instantiated variable must be completely new and not previously used in the proof.</source>
+        <translation>Fehler bei der existenziellen Instanziierung: Die instanziierte Variable muss völlig neu sein und darf im Beweis noch nicht verwendet worden sein.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation constructed incorrectly.</source>
+        <translation>Existenzielle Instanziierung falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation requires exactly one (1) reference.</source>
+        <translation>Existenzielle Instanziierung erfordert genau eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Exportation constructed incorrectly.</source>
+        <translation>Exportation falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Exportation requires one (1) reference.</source>
+        <translation>Exportation erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>File Error: Unable to open or read the specified lemma file.</source>
+        <translation>Dateifehler: Die angegebene Lemma-Datei konnte nicht geöffnet oder gelesen werden.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution Error: Neither premise&apos;s substitution matches the conclusion.</source>
+        <translation>Fehler bei der Substitution freier Variablen: Keine der Prämissensubstitutionen stimmt mit der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution Error: The substitution does not match the conclusion.</source>
+        <translation>Fehler bei der Substitution freier Variablen: Die Substitution stimmt nicht mit der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution requires one or two (1 or 2) references.</source>
+        <translation>Substitution freier Variablen erfordert eine oder zwei (1 oder 2) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Hypothetical Syllogism requires at least two (2) references.</source>
+        <translation>Hypothetischer Syllogismus erfordert mindestens zwei (2) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Idempotence constructed incorrectly.</source>
+        <translation>Idempotenz falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Idempotence requires one (1) reference.</source>
+        <translation>Idempotenz erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Identity requires zero (0) references.</source>
+        <translation>Identität erfordert null (0) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Implication Error: Expected equivalence between a conditional (P -&gt; Q) and a disjunction (~P v Q).</source>
+        <translation>Implikationsfehler: Es wurde eine Äquivalenz zwischen einem Konditional (P -&gt; Q) und einer Disjunktion (~P v Q) erwartet.</translation>
+    </message>
+    <message>
+        <source>Implication requires one (1) reference.</source>
+        <translation>Implikation erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Induction Error: The base case or inductive step does not match the universal conclusion.</source>
+        <translation>Induktionsfehler: Der Basisfall oder der Induktionsschritt stimmt nicht mit der allgemeinen Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>Induction requires two (2) references.</source>
+        <translation>Induktion erfordert zwei (2) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Internal error: this line could not be evaluated (out of memory).</source>
+        <translation>Interner Fehler: Diese Zeile konnte nicht ausgewertet werden (Speicher erschöpft).</translation>
+    </message>
+    <message>
+        <source>Invalid Reference: A referenced line has a syntax or evaluation error. First fix the error on that line.</source>
+        <translation>Ungültige Referenz: Eine referenzierte Zeile enthält einen Syntax- oder Auswertungsfehler. Zuerst den Fehler in dieser Zeile beheben.</translation>
+    </message>
+    <message>
+        <source>Invalid Reference: One or more referenced line numbers do not exist in this proof.</source>
+        <translation>Ungültige Referenz: Eine oder mehrere referenzierte Zeilennummern existieren in diesem Beweis nicht.</translation>
+    </message>
+    <message>
+        <source>Lemma Error: The number of references provided must exactly match the number of premises required by the lemma.</source>
+        <translation>Lemma-Fehler: Die Anzahl der angegebenen Referenzen muss genau der Anzahl der vom Lemma benötigten Prämissen entsprechen.</translation>
+    </message>
+    <message>
+        <source>Lemma Error: The referenced lemma does not match the premises or conclusion required by this line.</source>
+        <translation>Lemma-Fehler: Das referenzierte Lemma stimmt nicht mit den von dieser Zeile geforderten Prämissen oder der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>Missing Rule: Please select a justification rule for this proof line.</source>
+        <translation>Fehlende Regel: Bitte eine Begründungsregel für diese Beweiszeile auswählen.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: Neither the antecedent nor the consequence of the conditional matches the premise or conclusion. Check your references and line order.</source>
+        <translation>Modus-Ponens-Fehler: Weder das Antezedens noch das Konsequens des Konditionals stimmt mit der Prämisse oder der Konklusion überein. Referenzen und Zeilenreihenfolge prüfen.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: One of the references must be a conditional statement (-&gt;).</source>
+        <translation>Modus-Ponens-Fehler: Eine der Referenzen muss eine konditionale Aussage (-&gt;) sein.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: The antecedent of the conditional (-&gt;) does not match the minor premise reference.</source>
+        <translation>Modus-Ponens-Fehler: Das Antezedens des Konditionals (-&gt;) stimmt nicht mit der Referenz der Unterprämisse überein.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: The consequence of the conditional (-&gt;) does not match the conclusion.</source>
+        <translation>Modus-Ponens-Fehler: Das Konsequens des Konditionals (-&gt;) stimmt nicht mit der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens requires two (2) references.</source>
+        <translation>Modus Ponens erfordert zwei (2) Referenzen.</translation>
+    </message>
+    <message>
+        <source>None of the goals from the proof matched up with the conclusion.</source>
+        <translation>Keines der Ziele des Beweises stimmte mit der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>None of the references matched one of the proof premises.</source>
+        <translation>Keine der Referenzen stimmte mit einer der Beweisprämissen überein.</translation>
+    </message>
+    <message>
+        <source>Null Quantification requires one (1) reference.</source>
+        <translation>Nullquantifikation erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: Could not find a matching connective enclosing the quantifier.</source>
+        <translation>Nullquantor-Fehler: Es konnte keine passende, den Quantor umschließende Verknüpfung gefunden werden.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: Removing the quantifier does not produce a sentence matching the other line.</source>
+        <translation>Nullquantor-Fehler: Das Entfernen des Quantors ergibt keinen Satz, der mit der anderen Zeile übereinstimmt.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: The point of difference must be a quantifier with no free occurrences of its variable.</source>
+        <translation>Nullquantor-Fehler: Die Differenzstelle muss ein Quantor sein, dessen Variable keine freien Vorkommen hat.</translation>
+    </message>
+    <message>
+        <source>One of the antecedents did not match a disjunct from the reference.</source>
+        <translation>Eines der Antezedentien stimmte mit keinem Disjunkt der Referenz überein.</translation>
+    </message>
+    <message>
+        <source>One of the conclusion&apos;s disjuncts did not match a consequence.</source>
+        <translation>Eines der Disjunkte der Konklusion stimmte mit keinem Konsequens überein.</translation>
+    </message>
+    <message>
+        <source>One of the conjuncts in the conclusion does not match up with a reference.</source>
+        <translation>Eines der Konjunkte in der Konklusion stimmt mit keiner Referenz überein.</translation>
+    </message>
+    <message>
+        <source>One of the conjuncts in the reference must match the conclusion.</source>
+        <translation>Eines der Konjunkte in der Referenz muss mit der Konklusion übereinstimmen.</translation>
+    </message>
+    <message>
+        <source>One of the consequences did not match a disjunct from the conclusion.</source>
+        <translation>Eines der Konsequentien stimmte mit keinem Disjunkt der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>One of the consequences of a reference does not match an antecedent.</source>
+        <translation>Das Konsequens einer der Referenzen stimmt mit keinem Antezedens überein.</translation>
+    </message>
+    <message>
+        <source>One of the disjuncts does not correspond to a reference or the conclusion.</source>
+        <translation>Eines der Disjunkte entspricht keiner Referenz und nicht der Konklusion.</translation>
+    </message>
+    <message>
+        <source>One of the premises must contain an identity predicate.</source>
+        <translation>Eine der Prämissen muss ein Identitätsprädikat enthalten.</translation>
+    </message>
+    <message>
+        <source>One of the reference&apos;s disjuncts did not match an antecedent.</source>
+        <translation>Eines der Disjunkte der Referenz stimmte mit keinem Antezedens überein.</translation>
+    </message>
+    <message>
+        <source>One of the references does not match up with a conjunct in the conclusion.</source>
+        <translation>Eine der Referenzen stimmt mit keinem Konjunkt in der Konklusion überein.</translation>
+    </message>
+    <message>
+        <source>One of the references must contain an XOR as its top connective.</source>
+        <translation>Eine der Referenzen muss ein XOR als oberste Verknüpfung enthalten.</translation>
+    </message>
+    <message>
+        <source>One of the references or conclusion does not match up with a disjunct.</source>
+        <translation>Eine der Referenzen oder die Konklusion stimmt mit keinem Disjunkt überein.</translation>
+    </message>
+    <message>
+        <source>One sentence must contain a disjunction.</source>
+        <translation>Ein Satz muss eine Disjunktion enthalten.</translation>
+    </message>
+    <message>
+        <source>Only line 1 can be blank; subsequent blank lines are not allowed.</source>
+        <translation>Nur Zeile 1 darf leer sein; nachfolgende leere Zeilen sind nicht zulässig.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: Could not find a matching connective enclosing the quantifier.</source>
+        <translation>Pränex-Fehler: Es konnte keine passende, den Quantor umschließende Verknüpfung gefunden werden.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: Moving the quantifier does not produce a sentence matching the other line.</source>
+        <translation>Pränex-Fehler: Das Verschieben des Quantors ergibt keinen Satz, der mit der anderen Zeile übereinstimmt.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: The quantifier must be preceded by a connective for it to be moved.</source>
+        <translation>Pränex-Fehler: Dem Quantor muss eine Verknüpfung vorausgehen, damit er verschoben werden kann.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: The quantifier&apos;s scope must not be empty.</source>
+        <translation>Pränex-Fehler: Der Wirkungsbereich des Quantors darf nicht leer sein.</translation>
+    </message>
+    <message>
+        <source>Prenex requires one (1) reference.</source>
+        <translation>Pränex erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Rule &apos;sp&apos; (Subproof) can only reference the starting line of a subproof.</source>
+        <translation>Die Regel „sp“ (Teilbeweis) kann nur auf die Startzeile eines Teilbeweises verweisen.</translation>
+    </message>
+    <message>
+        <source>Rule not recognized.</source>
+        <translation>Regel nicht erkannt.</translation>
+    </message>
+    <message>
+        <source>Sequence requires zero (0) references.</source>
+        <translation>Folge erfordert null (0) Referenzen.</translation>
+    </message>
+    <message>
+        <source>Simplification requires one (1) reference.</source>
+        <translation>Vereinfachung erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Subproof Error: The premise of the subproof must match the conditional&apos;s antecedent, and the subproof conclusion must match the consequence.</source>
+        <translation>Teilbeweis-Fehler: Die Prämisse des Teilbeweises muss mit dem Antezedens des Konditionals übereinstimmen, und die Konklusion des Teilbeweises muss mit dem Konsequens übereinstimmen.</translation>
+    </message>
+    <message>
+        <source>Subproof Error: The rule &apos;sp&apos; requires a subproof line as a reference.</source>
+        <translation>Teilbeweis-Fehler: Die Regel „sp“ erfordert eine Teilbeweiszeile als Referenz.</translation>
+    </message>
+    <message>
+        <source>Subsumption constructed incorrectly.</source>
+        <translation>Subsumtion falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around a connective.</source>
+        <translation>Subsumtion muss um eine Verknüpfung herum durchgeführt werden.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around a disjunction or a conjunction.</source>
+        <translation>Subsumtion muss um eine Disjunktion oder eine Konjunktion herum durchgeführt werden.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around two connectives.</source>
+        <translation>Subsumtion muss um zwei Verknüpfungen herum durchgeführt werden.</translation>
+    </message>
+    <message>
+        <source>Subsumption requires one (1) reference.</source>
+        <translation>Subsumtion erfordert eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Symbol Negation Error: Expected negation of a Boolean constant symbol.</source>
+        <translation>Fehler bei der Symbolnegation: Es wurde die Negation eines booleschen Konstantensymbols erwartet.</translation>
+    </message>
+    <message>
+        <source>Symbol Negation requires exactly one (1) reference.</source>
+        <translation>Symbolnegation erfordert genau eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Chaining conditionals (-&gt;), biconditionals (&lt;-&gt;), or XOR without enclosing parentheses is ambiguous.</source>
+        <translation>Syntaxfehler: Die Verkettung von Konditionalen (-&gt;), Bikonditionalen (&lt;-&gt;) oder XOR ohne umschließende Klammern ist mehrdeutig.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Individual terms and variables must start with a lowercase letter (a-z) or number.</source>
+        <translation>Syntaxfehler: Einzelterme und Variablen müssen mit einem Kleinbuchstaben (a-z) oder einer Zahl beginnen.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Invalid characters in symbol name or empty argument parentheses &apos;()&apos;.</source>
+        <translation>Syntaxfehler: Ungültige Zeichen im Symbolnamen oder leere Argumentklammern „()“.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Mismatched parentheses. Check opening and closing brackets.</source>
+        <translation>Syntaxfehler: Nicht übereinstimmende Klammern. Öffnende und schließende Klammern prüfen.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Predicate or propositional variable names must start with an uppercase letter (A-Z).</source>
+        <translation>Syntaxfehler: Prädikat- oder Aussagevariablennamen müssen mit einem Großbuchstaben (A-Z) beginnen.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: The sentence has syntactical errors.</source>
+        <translation>Syntaxfehler: Der Satz enthält syntaktische Fehler.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Unrecognized or invalid logical connective symbol.</source>
+        <translation>Syntaxfehler: Unbekanntes oder ungültiges logisches Verknüpfungssymbol.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Unrecognized or invalid quantifier symbol.</source>
+        <translation>Syntaxfehler: Unbekanntes oder ungültiges Quantorensymbol.</translation>
+    </message>
+    <message>
+        <source>The conclusion must contain an XOR.</source>
+        <translation>Die Konklusion muss ein XOR enthalten.</translation>
+    </message>
+    <message>
+        <source>The conclusion must have an identity predicate.</source>
+        <translation>Die Konklusion muss ein Identitätsprädikat aufweisen.</translation>
+    </message>
+    <message>
+        <source>The conclusion must start with a universal.</source>
+        <translation>Die Konklusion muss mit einem Allquantor beginnen.</translation>
+    </message>
+    <message>
+        <source>The connective must be a conjunction or disjunction.</source>
+        <translation>Die Verknüpfung muss eine Konjunktion oder Disjunktion sein.</translation>
+    </message>
+    <message>
+        <source>The difference must be a bound variable.</source>
+        <translation>Die Differenzstelle muss eine gebundene Variable sein.</translation>
+    </message>
+    <message>
+        <source>The difference must be a quantifier.</source>
+        <translation>Die Differenzstelle muss ein Quantor sein.</translation>
+    </message>
+    <message>
+        <source>The final argument of the sequence&apos;s function must be the variable.</source>
+        <translation>Das letzte Argument der Folgenfunktion muss die Variable sein.</translation>
+    </message>
+    <message>
+        <source>The first argument must be a value function.</source>
+        <translation>Das erste Argument muss eine Wertfunktion sein.</translation>
+    </message>
+    <message>
+        <source>The left disjunct must be the negation of the right disjunct.</source>
+        <translation>Das linke Disjunkt muss die Negation des rechten Disjunkts sein.</translation>
+    </message>
+    <message>
+        <source>The left disjunct must have a negation.</source>
+        <translation>Das linke Disjunkt muss eine Negation aufweisen.</translation>
+    </message>
+    <message>
+        <source>The minor premise and conclusion do not match the XOR disjuncts correctly.</source>
+        <translation>Die Unterprämisse und die Konklusion stimmen nicht korrekt mit den XOR-Disjunkten überein.</translation>
+    </message>
+    <message>
+        <source>The negation sentence must be negating either a conjunction or a disjunction.</source>
+        <translation>Der negierte Satz muss entweder eine Konjunktion oder eine Disjunktion negieren.</translation>
+    </message>
+    <message>
+        <source>The new variable did not appear in the conclusion.</source>
+        <translation>Die neue Variable kam in der Konklusion nicht vor.</translation>
+    </message>
+    <message>
+        <source>The quantifiers must be the same.</source>
+        <translation>Die Quantoren müssen identisch sein.</translation>
+    </message>
+    <message>
+        <source>The reference must be the first disjunct in the conclusion.</source>
+        <translation>Die Referenz muss das erste Disjunkt in der Konklusion sein.</translation>
+    </message>
+    <message>
+        <source>The rest of the sentences must be the same.</source>
+        <translation>Der Rest der Sätze muss identisch sein.</translation>
+    </message>
+    <message>
+        <source>The second part must be the negation of the first.</source>
+        <translation>Der zweite Teil muss die Negation des ersten sein.</translation>
+    </message>
+    <message>
+        <source>The sequence must only be used once.</source>
+        <translation>Die Folge darf nur einmal verwendet werden.</translation>
+    </message>
+    <message>
+        <source>The sequence variable must not have been used before.</source>
+        <translation>Die Folgenvariable darf zuvor nicht verwendet worden sein.</translation>
+    </message>
+    <message>
+        <source>The top connective must change between sentences.</source>
+        <translation>Die oberste Verknüpfung muss sich zwischen den Sätzen ändern.</translation>
+    </message>
+    <message>
+        <source>The two arguments to the identity predicate must be the same.</source>
+        <translation>Die beiden Argumente des Identitätsprädikats müssen identisch sein.</translation>
+    </message>
+    <message>
+        <source>The two connectives must be complementary to one another.</source>
+        <translation>Die beiden Verknüpfungen müssen zueinander komplementär sein.</translation>
+    </message>
+    <message>
+        <source>The two references must match the two disjuncts of the XOR conclusion.</source>
+        <translation>Die beiden Referenzen müssen mit den beiden Disjunkten der XOR-Konklusion übereinstimmen.</translation>
+    </message>
+    <message>
+        <source>The two sentences must be of different lengths.</source>
+        <translation>Die beiden Sätze müssen unterschiedlich lang sein.</translation>
+    </message>
+    <message>
+        <source>The variable must be the second argument of the value function.</source>
+        <translation>Die Variable muss das zweite Argument der Wertfunktion sein.</translation>
+    </message>
+    <message>
+        <source>The variable must be used only twice.</source>
+        <translation>Die Variable darf nur zweimal verwendet werden.</translation>
+    </message>
+    <message>
+        <source>The variables must not appear in the scope.</source>
+        <translation>Die Variablen dürfen im Wirkungsbereich nicht vorkommen.</translation>
+    </message>
+    <message>
+        <source>There must be a biconditional in one sentence.</source>
+        <translation>In einem Satz muss ein Bikonditional vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a conditional in both sentences.</source>
+        <translation>In beiden Sätzen muss ein Konditional vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a conditional in the conclusion.</source>
+        <translation>In der Konklusion muss ein Konditional vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction in the conclusion.</source>
+        <translation>In der Konklusion muss eine Konjunktion vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction in the reference.</source>
+        <translation>In der Referenz muss eine Konjunktion vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction or a disjunction at the difference.</source>
+        <translation>An der Differenzstelle muss eine Konjunktion oder eine Disjunktion vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction or a disjunction in one sentence.</source>
+        <translation>In einem Satz muss eine Konjunktion oder eine Disjunktion vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a connective at the difference.</source>
+        <translation>An der Differenzstelle muss eine Verknüpfung vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in both sentences.</source>
+        <translation>In beiden Sätzen muss eine Verknüpfung vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in one sentence.</source>
+        <translation>In einem Satz muss eine Verknüpfung vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in the longer sentence.</source>
+        <translation>Im längeren Satz muss eine Verknüpfung vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a disjunction in the conclusion.</source>
+        <translation>In der Konklusion muss eine Disjunktion vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a disjunction in the longest reference.</source>
+        <translation>In der längsten Referenz muss eine Disjunktion vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a negated symbol in one sentence.</source>
+        <translation>In einem Satz muss ein negiertes Symbol vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a negation at the difference.</source>
+        <translation>An der Differenzstelle muss eine Negation vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a negation in one sentence.</source>
+        <translation>In einem Satz muss eine Negation vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a quantifier after the negation.</source>
+        <translation>Nach der Negation muss ein Quantor vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a quantifier at the difference.</source>
+        <translation>An der Differenzstelle muss ein Quantor vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a tautology or a contradiction in the generalities.</source>
+        <translation>In den Allgemeinheiten muss eine Tautologie oder ein Widerspruch vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a tautology or a contradiction within the difference.</source>
+        <translation>Innerhalb der Differenzstelle muss eine Tautologie oder ein Widerspruch vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be a universal at the beginning of the conclusion.</source>
+        <translation>Am Anfang der Konklusion muss ein Allquantor stehen.</translation>
+    </message>
+    <message>
+        <source>There must be an identity predicate in the scope.</source>
+        <translation>Im Wirkungsbereich muss ein Identitätsprädikat vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be connectives on both sentences.</source>
+        <translation>In beiden Sätzen müssen Verknüpfungen vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be generalities at the difference.</source>
+        <translation>An der Differenzstelle müssen Allgemeinheiten vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be generalities in the scope.</source>
+        <translation>Im Wirkungsbereich müssen Allgemeinheiten vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be more than one generality for distribution.</source>
+        <translation>Für die Distribution muss mehr als eine Allgemeinheit vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be only two connected parts.</source>
+        <translation>Es dürfen nur zwei verknüpfte Teile vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be only two parts for distribution.</source>
+        <translation>Für die Distribution dürfen nur zwei Teile vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>There must be quantifiers at the difference.</source>
+        <translation>An der Differenzstelle müssen Quantoren vorhanden sein.</translation>
+    </message>
+    <message>
+        <source>Universal Generalization Error: The generalized variable must be arbitrary (not introduced by Existential Instantiation or unclosed assumptions).</source>
+        <translation>Fehler bei der universellen Generalisierung: Die generalisierte Variable muss beliebig sein (nicht durch existenzielle Instanziierung oder nicht geschlossene Annahmen eingeführt).</translation>
+    </message>
+    <message>
+        <source>Universal Generalization constructed incorrectly.</source>
+        <translation>Universelle Generalisierung falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Universal Generalization requires exactly one (1) reference.</source>
+        <translation>Universelle Generalisierung erfordert genau eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>Universal Instantiation constructed incorrectly.</source>
+        <translation>Universelle Instanziierung falsch konstruiert.</translation>
+    </message>
+    <message>
+        <source>Universal Instantiation requires exactly one (1) reference.</source>
+        <translation>Universelle Instanziierung erfordert genau eine (1) Referenz.</translation>
+    </message>
+    <message>
+        <source>XOR Elimination requires exactly two (2) references.</source>
+        <translation>XOR-Elimination erfordert genau zwei (2) Referenzen.</translation>
+    </message>
+    <message>
+        <source>XOR Introduction requires exactly two (2) references.</source>
+        <translation>XOR-Einführung erfordert genau zwei (2) Referenzen.</translation>
     </message>
 </context>
 </TS>

--- a/qt/i18n/aris-qt_fr.ts
+++ b/qt/i18n/aris-qt_fr.ts
@@ -2,127 +2,1516 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="fr_FR" sourcelanguage="en_US">
 <context>
-    <name>KeyGroup</name>
-    <message><source>Conjunction</source><translation>Conjonction</translation></message>
-    <message><source>Disjunction</source><translation>Disjonction</translation></message>
-    <message><source>Negation</source><translation>Négation</translation></message>
-    <message><source>Implication</source><translation>Implication</translation></message>
-    <message><source>Bi-conditional</source><translation>Biconditionnel</translation></message>
-    <message><source>For all</source><translation>Pour tout</translation></message>
-    <message><source>There exists</source><translation>Il existe</translation></message>
-    <message><source>Tautology</source><translation>Tautologie</translation></message>
-    <message><source>Contradiction</source><translation>Contradiction</translation></message>
-    <message><source>Belongs To</source><translation>Appartient à</translation></message>
-    <message><source>Null</source><translation>Vide</translation></message>
-    <message><source>XOR</source><translation>OU exclusif</translation></message>
+    <name>Connector</name>
+    <message>
+        <location filename="../connector.cpp" line="415"/>
+        <source>Line %1 · %2: %3</source>
+        <translation>Ligne %1 · %2 : %3</translation>
+    </message>
+    <message>
+        <location filename="../connector.cpp" line="481"/>
+        <source>File save failed for path: %1</source>
+        <translation>Échec de l&apos;enregistrement du fichier vers : %1</translation>
+    </message>
+    <message>
+        <location filename="../connector.cpp" line="514"/>
+        <source>File open failed for path: %1</source>
+        <translation>Échec de l&apos;ouverture du fichier : %1</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Évaluer la preuve</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>Correct !</translation>
+    </message>
+    <message>
+        <source>Errors found</source>
+        <translation>Erreurs détectées</translation>
+    </message>
 </context>
 <context>
     <name>DrawerTools</name>
-    <message><source>New</source><translation>Nouveau</translation></message>
-    <message><source>Reset</source><translation>Réinitialiser</translation></message>
-    <message><source>Open</source><translation>Ouvrir</translation></message>
-    <message><source>Save</source><translation>Enregistrer</translation></message>
-    <message><source>Save As</source><translation>Enregistrer sous</translation></message>
-    <message><source>Export To LaTeX</source><translation>Exporter vers LaTeX</translation></message>
-    <message><source>Toggle Goals</source><translation>Basculer les objectifs</translation></message>
-    <message><source>Toggle Dark Mode</source><translation>Basculer le mode sombre</translation></message>
-    <message><source>Zoom</source><translation>Zoomer</translation></message>
-    <message><source>Reset Zoom</source><translation>Réinitialiser le zoom</translation></message>
-    <message><source>Paste Proof from Clipboard</source><translation>Coller la preuve depuis le presse-papiers</translation></message>
-    <message><source>(Ctrl+Shift+V)</source><translation>(Ctrl+Maj+V)</translation></message>
-    <message><source>Copy Selected Lines</source><translation>Copier les lignes sélectionnées</translation></message>
-    <message><source>(Ctrl+Shift+C)</source><translation>(Ctrl+Maj+C)</translation></message>
-    <message><source>Import Proof</source><translation>Importer la preuve</translation></message>
-    <message><source>Font</source><translation>Police</translation></message>
-    <message><source>Language</source><translation>Langue</translation></message>
-    <message><source>Help</source><translation>Aide</translation></message>
-    <message><source>About</source><translation>À propos</translation></message>
+    <message>
+        <location filename="../DrawerTools.qml" line="37"/>
+        <source>New</source>
+        <translation>Nouveau</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="50"/>
+        <source>Reset</source>
+        <translation>Réinitialiser</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="59"/>
+        <source>Open</source>
+        <translation>Ouvrir</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="77"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="96"/>
+        <source>Save As</source>
+        <translation>Enregistrer sous</translation>
+    </message>
+    <message>
+        <source>Export To LaTeX</source>
+        <translation type="vanished">Exporter vers LaTeX</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="107"/>
+        <source>Export</source>
+        <translation>Exporter</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="122"/>
+        <source>Toggle Goals</source>
+        <translation>Basculer les objectifs</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="136"/>
+        <source>Toggle Dark Mode</source>
+        <translation>Basculer le mode sombre</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="164"/>
+        <source>Zoom</source>
+        <translation>Zoomer</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="213"/>
+        <source>Reset Zoom</source>
+        <translation>Réinitialiser le zoom</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="220"/>
+        <source>Paste Proof from Clipboard</source>
+        <translation>Coller la preuve depuis le presse-papiers</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="226"/>
+        <source>(Ctrl+Shift+V)</source>
+        <translation>(Ctrl+Maj+V)</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="235"/>
+        <source>Copy Selected Lines</source>
+        <translation>Copier les lignes sélectionnées</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="241"/>
+        <source>(Ctrl+Shift+C)</source>
+        <translation>(Ctrl+Maj+C)</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="250"/>
+        <source>Import Proof</source>
+        <translation>Importer la preuve</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="262"/>
+        <source>Font</source>
+        <translation>Police</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="272"/>
+        <source>Language</source>
+        <translation>Langue</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="315"/>
+        <source>Help</source>
+        <translation>Aide</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="323"/>
+        <source>About</source>
+        <translation>À propos</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Évaluer la preuve</translation>
+    </message>
+</context>
+<context>
+    <name>GoalLine</name>
+    <message>
+        <location filename="../GoalLine.qml" line="163"/>
+        <source>Invalid Operation: At least one goal line must remain.</source>
+        <translation>Opération invalide : au moins un objectif doit être conservé.</translation>
+    </message>
+</context>
+<context>
+    <name>KeyGroup</name>
+    <message>
+        <location filename="../KeyGroup.qml" line="37"/>
+        <source>Conjunction</source>
+        <translation>Conjonction</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="44"/>
+        <source>Disjunction</source>
+        <translation>Disjonction</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="51"/>
+        <source>Negation</source>
+        <translation>Négation</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="58"/>
+        <source>Implication</source>
+        <translation>Implication</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="65"/>
+        <source>Bi-conditional</source>
+        <translation>Biconditionnel</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="72"/>
+        <source>For all</source>
+        <translation>Pour tout</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="79"/>
+        <source>There exists</source>
+        <translation>Il existe</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="86"/>
+        <source>Tautology</source>
+        <translation>Tautologie</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="93"/>
+        <source>Contradiction</source>
+        <translation>Contradiction</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="100"/>
+        <source>Belongs To</source>
+        <translation>Appartient à</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="107"/>
+        <source>Null</source>
+        <translation>Vide</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="114"/>
+        <source>XOR</source>
+        <translation>OU exclusif</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Évaluer la preuve</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>Correct !</translation>
+    </message>
+</context>
+<context>
+    <name>ProofArea</name>
+    <message>
+        <location filename="../ProofArea.qml" line="606"/>
+        <source>Confirm Conversion</source>
+        <translation>Confirmer la conversion</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="623"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="635"/>
+        <source>Convert Anyway</source>
+        <translation>Convertir quand même</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="439"/>
+        <source>Convert</source>
+        <translation>Convertir</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="226"/>
+        <location filename="../ProofArea.qml" line="261"/>
+        <location filename="../ProofArea.qml" line="285"/>
+        <location filename="../ProofArea.qml" line="313"/>
+        <location filename="../ProofArea.qml" line="353"/>
+        <source>No line selected.</source>
+        <translation>Aucune ligne sélectionnée.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="362"/>
+        <source>Cannot convert structural subproof lines.</source>
+        <translation>Impossible de convertir les lignes structurelles d&apos;une sous-preuve.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="369"/>
+        <source>Proof must contain at least one premise.</source>
+        <translation>La preuve doit contenir au moins une prémisse.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="441"/>
+        <location filename="../ProofArea.qml" line="1448"/>
+        <source>Convert to Conclusion</source>
+        <translation>Convertir en conclusion</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="441"/>
+        <location filename="../ProofArea.qml" line="1448"/>
+        <source>Convert to Premise</source>
+        <translation>Convertir en prémisse</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="480"/>
+        <source>Add Premise Above</source>
+        <translation>Ajouter une prémisse au-dessus</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="498"/>
+        <source>Add Conclusion Below</source>
+        <translation>Ajouter une conclusion en dessous</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="517"/>
+        <source>Add Comment Below</source>
+        <translation>Ajouter un commentaire en dessous</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="869"/>
+        <source>Expand subproof</source>
+        <translation>Développer la sous-preuve</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="869"/>
+        <source>Collapse subproof</source>
+        <translation>Réduire la sous-preuve</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="901"/>
+        <source>Invalid Operation: A proof line can only reference earlier line numbers.</source>
+        <translation>Opération invalide : une ligne de preuve ne peut référencer que des numéros de ligne antérieurs.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="906"/>
+        <source>Invalid Operation: Cannot assign inference rules or references to a premise.</source>
+        <translation>Opération invalide : impossible d&apos;assigner une règle d&apos;inférence ou des références à une prémisse.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="912"/>
+        <source>Invalid Operation: Cannot modify or reference the start line of a subproof directly.</source>
+        <translation>Opération invalide : impossible de modifier ou de référencer directement la ligne de début d&apos;une sous-preuve.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="919"/>
+        <source>Invalid Operation: Cannot reference lines across closed subproof boundaries.</source>
+        <translation>Opération invalide : impossible de référencer des lignes au-delà des limites d&apos;une sous-preuve fermée.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1404"/>
+        <source>Add Premise</source>
+        <translation>Ajouter une prémisse</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1418"/>
+        <source>Add Conclusion</source>
+        <translation>Ajouter une conclusion</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1434"/>
+        <source>Add Comment</source>
+        <translation>Ajouter un commentaire</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1484"/>
+        <source>Start Subproof</source>
+        <translation>Démarrer la sous-preuve</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1498"/>
+        <source>End Subproof</source>
+        <translation>Terminer la sous-preuve</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1516"/>
+        <source>Remove this Line</source>
+        <translation>Supprimer cette ligne</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1172"/>
+        <source>premise</source>
+        <translation>prémisse</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1173"/>
+        <source>subproof</source>
+        <translation>sous-preuve</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1174"/>
+        <source>sf</source>
+        <translation>fs</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <source>Inference</source>
+        <translation>Inférence</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Equivalence</source>
+        <translation>Équivalence</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <source>Predicate</source>
+        <translation>Prédicat</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <source>Miscellaneous</source>
+        <translation>Divers</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <source>Boolean</source>
+        <translation>Booléen</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Modus Ponens</source>
+        <translation>Modus Ponens</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Addition</source>
+        <translation>Addition</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Simplification</source>
+        <translation>Simplification</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Conjunction</source>
+        <translation>Conjonction</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Hypothetical Syllogism</source>
+        <translation>Syllogisme hypothétique</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Disjunctive Syllogism</source>
+        <translation>Syllogisme disjonctif</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Excluded middle</source>
+        <translation>Tiers exclu</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>Constructive Dilemma</source>
+        <translation>Dilemme constructif</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>XOR Introduction</source>
+        <translation>Introduction de OU exclusif</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="119"/>
+        <source>XOR Elimination</source>
+        <translation>Élimination de OU exclusif</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Implication</source>
+        <translation>Implication</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>DeMorgan</source>
+        <translation>De Morgan</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Association</source>
+        <translation>Association</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Commutativity</source>
+        <translation>Commutativité</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Idempotence</source>
+        <translation>Idempotence</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Distribution</source>
+        <translation>Distribution</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Double Negation</source>
+        <translation>Double Négation</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Exportation</source>
+        <translation>Exportation</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Subsumption</source>
+        <translation>Subsomption</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="120"/>
+        <source>Contrapositive</source>
+        <translation>Contraposée</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Universal Generalization</source>
+        <translation>Généralisation universelle</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Universal Instantiation</source>
+        <translation>Instanciation universelle</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Existential Generalization</source>
+        <translation>Généralisation existentielle</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Existential Instantiation</source>
+        <translation>Instanciation existentielle</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Bound Variable Substitution</source>
+        <translation>Substitution de variable liée</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Null Quantifier</source>
+        <translation>Quantificateur nul</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Prenex</source>
+        <translation>Prénexe</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Identity</source>
+        <translation>Identité</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="121"/>
+        <source>Free Variable Substitution</source>
+        <translation>Substitution de variable libre</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="122"/>
+        <source>Lemma</source>
+        <translation>Lemme</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="122"/>
+        <source>Subproof</source>
+        <translation>Sous-preuve</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="122"/>
+        <source>Sequence</source>
+        <translation>Séquence</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="122"/>
+        <source>Induction</source>
+        <translation>Induction</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="123"/>
+        <source>Identity </source>
+        <translation>Identité </translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="123"/>
+        <source>Negation</source>
+        <translation>Négation</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="123"/>
+        <source>Dominance</source>
+        <translation>Dominance</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="123"/>
+        <source>Symbol Negation</source>
+        <translation>Négation de symbole</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Évaluer la preuve</translation>
+    </message>
+</context>
+<context>
+    <name>auxConnector</name>
+    <message>
+        <location filename="../auxconnector.cpp" line="122"/>
+        <source>LaTeX export failed: could not convert proof to LaTeX format.</source>
+        <translation>Échec de l&apos;export LaTeX : impossible de convertir la preuve au format LaTeX.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="165"/>
+        <source>Import failed: the selected file could not be opened or is not a valid Aris proof.</source>
+        <translation>Échec de l&apos;import : le fichier sélectionné n&apos;a pas pu être ouvert ou n&apos;est pas une preuve Aris valide.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="481"/>
+        <source>Text export failed: could not open &apos;%1&apos; for writing.</source>
+        <translation>Échec de l&apos;export texte : impossible d&apos;ouvrir « %1 » en écriture.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="551"/>
+        <source>Markdown export failed: could not open &apos;%1&apos; for writing.</source>
+        <translation>Échec de l&apos;export Markdown : impossible d&apos;ouvrir « %1 » en écriture.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="855"/>
+        <source>ODT export failed: could not write to &apos;%1&apos;.</source>
+        <translation>Échec de l&apos;export ODT : impossible d&apos;écrire dans « %1 ».</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="896"/>
+        <source>PDF export is not available on your device.</source>
+        <translation>L&apos;export PDF n&apos;est pas disponible sur cet appareil.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="915"/>
+        <source>PDF export failed: could not write to &apos;%1&apos;.</source>
+        <translation>Échec de l&apos;export PDF : impossible d&apos;écrire dans « %1 ».</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="933"/>
+        <source>PDF export is not available in the browser version.</source>
+        <translation>L&apos;export PDF n&apos;est pas disponible dans la version navigateur.</translation>
+    </message>
 </context>
 <context>
     <name>main</name>
     <message>
+        <location filename="../main.qml" line="166"/>
+        <source>Got it</source>
+        <translation>Compris</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="201"/>
         <source>QT_LAYOUT_DIRECTION</source>
         <comment>QGuiApplication</comment>
         <translation>LTR</translation>
     </message>
-    <message><source>Unsaved changes</source><translation>Modifications non enregistrées</translation></message>
-    <message><source>Save file before closing?</source><translation>Enregistrer le fichier avant de fermer ?</translation></message>
-    <message><source>Save new file before closing?</source><translation>Enregistrer le nouveau fichier avant de fermer ?</translation></message>
-    <message><source>Reset the current proof and goals?</source><translation>Réinitialiser la preuve actuelle et les objectifs ?</translation></message>
-    <message><source>Cancel</source><translation>Annuler</translation></message>
-    <message><source>Reset</source><translation>Réinitialiser</translation></message>
-    <message><source>Choose import behavior</source><translation>Choisir le comportement d'importation</translation></message>
-    <message><source>Overwrite</source><translation>Écraser</translation></message>
-    <message><source>Append End</source><translation>Ajouter à la fin</translation></message>
-    <message><source>Prepend</source><translation>Ajouter au début</translation></message>
+    <message>
+        <location filename="../main.qml" line="563"/>
+        <source>Unsaved changes</source>
+        <translation>Modifications non enregistrées</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="593"/>
+        <source>Save file before closing?</source>
+        <translation>Enregistrer le fichier avant de fermer ?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
+        <source>Save new file before closing?</source>
+        <translation>Enregistrer le nouveau fichier avant de fermer ?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="628"/>
+        <source>Reset the current proof and goals?</source>
+        <translation>Réinitialiser la preuve actuelle et les objectifs ?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="637"/>
+        <location filename="../main.qml" line="1093"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="649"/>
+        <source>Reset</source>
+        <translation>Réinitialiser</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="696"/>
+        <source>Choose import behavior</source>
+        <translation>Choisir le comportement d&apos;importation</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="705"/>
+        <source>Overwrite</source>
+        <translation>Écraser</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="717"/>
+        <source>Append End</source>
+        <translation>Ajouter à la fin</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="729"/>
+        <source>Prepend</source>
+        <translation>Ajouter au début</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="774"/>
+        <source>Choose export format</source>
+        <translation>Choisir le format d&apos;export</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="783"/>
+        <source>LaTeX</source>
+        <translation>LaTeX</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="799"/>
+        <source>Plain Text</source>
+        <translation>Texte brut</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="815"/>
+        <source>Markdown</source>
+        <translation>Markdown</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="869"/>
+        <source>Choose save format</source>
+        <translation>Choisir le format d&apos;enregistrement</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="881"/>
+        <source>Aris (.tle)</source>
+        <translation>Aris (.tle)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="904"/>
+        <source>ODT (.odt)</source>
+        <translation>ODT (.odt)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="926"/>
+        <source>PDF (.pdf)</source>
+        <translation>PDF (.pdf)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1014"/>
+        <source>Jump to Line</source>
+        <translation>Aller à la ligne</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1026"/>
+        <source>Invalid line number. Must be between 1 and </source>
+        <translation>Numéro de ligne invalide. Doit être compris entre 1 et </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1054"/>
+        <source>Line number</source>
+        <translation>Numéro de ligne</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1103"/>
+        <source>Jump</source>
+        <translation>Aller</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Évaluer la preuve</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>Correct !</translation>
+    </message>
+    <message>
+        <source>Errors found</source>
+        <translation>Erreurs détectées</translation>
+    </message>
+    <message>
+        <source>Errors found — see inline details above each failing line.</source>
+        <translation>Erreurs détectées — voir les détails au-dessus de chaque ligne en erreur.</translation>
+    </message>
 </context>
 <context>
-    <name>ProofArea</name>
-    <message><source>Confirm Conversion</source><translation>Confirmer la conversion</translation></message>
-    <message><source>Cancel</source><translation>Annuler</translation></message>
-    <message><source>Convert Anyway</source><translation>Convertir quand même</translation></message>
-    <message><source>Convert</source><translation>Convertir</translation></message>
-    <message><source>Convert to Conclusion</source><translation>Convertir en conclusion</translation></message>
-    <message><source>Convert to Premise</source><translation>Convertir en prémisse</translation></message>
-
-    <message><source>Add Premise Above</source><translation>Ajouter une prémisse au-dessus</translation></message>
-    <message><source>Add Conclusion Below</source><translation>Ajouter une conclusion en dessous</translation></message>
-    <message><source>Add Premise</source><translation>Ajouter une prémisse</translation></message>
-    <message><source>Add Conclusion</source><translation>Ajouter une conclusion</translation></message>
-    <message><source>Start Subproof</source><translation>Démarrer la sous-preuve</translation></message>
-    <message><source>End Subproof</source><translation>Terminer la sous-preuve</translation></message>
-    <message><source>Remove this Line</source><translation>Supprimer cette ligne</translation></message>
-
-    <message><source>premise</source><translation>prémisse</translation></message>
-    <message><source>subproof</source><translation>sous-preuve</translation></message>
-    <message><source>sf</source><translation>fs</translation></message>
-
-    <message><source>Inference</source><translation>Inférence</translation></message>
-    <message><source>Equivalence</source><translation>Équivalence</translation></message>
-    <message><source>Predicate</source><translation>Prédicat</translation></message>
-    <message><source>Miscellaneous</source><translation>Divers</translation></message>
-    <message><source>Boolean</source><translation>Booléen</translation></message>
-
-    <message><source>Modus Ponens</source><translation>Modus Ponens</translation></message>
-    <message><source>Addition</source><translation>Addition</translation></message>
-    <message><source>Simplification</source><translation>Simplification</translation></message>
-    <message><source>Conjunction</source><translation>Conjonction</translation></message>
-    <message><source>Hypothetical Syllogism</source><translation>Syllogisme hypothétique</translation></message>
-    <message><source>Disjunctive Syllogism</source><translation>Syllogisme disjonctif</translation></message>
-    <message><source>Excluded middle</source><translation>Tiers exclu</translation></message>
-    <message><source>Constructive Dilemma</source><translation>Dilemme constructif</translation></message>
-    <message><source>XOR Introduction</source><translation>Introduction de OU exclusif</translation></message>
-    <message><source>XOR Elimination</source><translation>Élimination de OU exclusif</translation></message>
-
-    <message><source>Implication</source><translation>Implication</translation></message>
-    <message><source>DeMorgan</source><translation>De Morgan</translation></message>
-    <message><source>Association</source><translation>Association</translation></message>
-    <message><source>Commutativity</source><translation>Commutativité</translation></message>
-    <message><source>Idempotence</source><translation>Idempotence</translation></message>
-    <message><source>Distribution</source><translation>Distribution</translation></message>
-    <message><source>Double Negation</source><translation>Double Négation</translation></message>
-    <message><source>Exportation</source><translation>Exportation</translation></message>
-    <message><source>Subsumption</source><translation>Subsomption</translation></message>
-    <message><source>Contrapositive</source><translation>Contraposée</translation></message>
-
-    <message><source>Universal Generalization</source><translation>Généralisation universelle</translation></message>
-    <message><source>Universal Instantiation</source><translation>Instanciation universelle</translation></message>
-    <message><source>Existential Generalization</source><translation>Généralisation existentielle</translation></message>
-    <message><source>Existential Instantiation</source><translation>Instanciation existentielle</translation></message>
-    <message><source>Bound Variable Substitution</source><translation>Substitution de variable liée</translation></message>
-    <message><source>Null Quantifier</source><translation>Quantificateur nul</translation></message>
-    <message><source>Prenex</source><translation>Prénexe</translation></message>
-    <message><source>Identity</source><translation>Identité</translation></message>
-    <message><source>Free Variable Substitution</source><translation>Substitution de variable libre</translation></message>
-
-    <message><source>Lemma</source><translation>Lemme</translation></message>
-    <message><source>Subproof</source><translation>Sous-preuve</translation></message>
-    <message><source>Sequence</source><translation>Séquence</translation></message>
-    <message><source>Induction</source><translation>Induction</translation></message>
-
-    <message><source>Identity </source><translation>Identité </translation></message>
-    <message><source>Negation</source><translation>Négation</translation></message>
-    <message><source>Dominance</source><translation>Dominance</translation></message>
-    <message><source>Symbol Negation</source><translation>Négation de symbole</translation></message>
+    <name>ProofErrors</name>
+    <message>
+        <source>A proof must be specified.</source>
+        <translation>Une preuve doit être spécifiée.</translation>
+    </message>
+    <message>
+        <source>A tautology must be matched with a conjunction, and a contradiction with a disjunction.</source>
+        <translation>Une tautologie doit correspondre à une conjonction, et une contradiction à une disjonction.</translation>
+    </message>
+    <message>
+        <source>Addition requires one (1) reference.</source>
+        <translation>Addition nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>All of the references except the disjunction reference must contain a conditional.</source>
+        <translation>Toutes les références sauf celle de la disjonction doivent contenir une conditionnelle.</translation>
+    </message>
+    <message>
+        <source>All of the references must be used.</source>
+        <translation>Toutes les références doivent être utilisées.</translation>
+    </message>
+    <message>
+        <source>All of the references must contain a conditional.</source>
+        <translation>Toutes les références doivent contenir une conditionnelle.</translation>
+    </message>
+    <message>
+        <source>Association constructed incorrectly.</source>
+        <translation>Association mal construite.</translation>
+    </message>
+    <message>
+        <source>Association must be done on a conjunction or disjunction.</source>
+        <translation>L&apos;association doit être effectuée sur une conjonction ou une disjonction.</translation>
+    </message>
+    <message>
+        <source>Association requires one (1) reference.</source>
+        <translation>Association nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Boolean Dominance Error: Expected absorption with True/False constants.</source>
+        <translation>Erreur de dominance booléenne : une absorption avec les constantes Vrai/Faux était attendue.</translation>
+    </message>
+    <message>
+        <source>Boolean Domination requires one (1) reference.</source>
+        <translation>Dominance booléenne nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: Could not align the longer sentence&apos;s structure with the point of difference.</source>
+        <translation>Erreur d&apos;identité booléenne : impossible d&apos;aligner la structure de la phrase la plus longue avec le point de différence.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: Simplifying or expanding the True/False constant does not produce a sentence matching the other line.</source>
+        <translation>Erreur d&apos;identité booléenne : simplifier ou développer la constante Vrai/Faux ne produit pas une phrase correspondant à l&apos;autre ligne.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: The difference must be enclosed by a connective, not at the very start of the sentence.</source>
+        <translation>Erreur d&apos;identité booléenne : la différence doit être englobée par un connecteur, et non se trouver tout au début de la phrase.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: The longer sentence must have a connective at the point of difference.</source>
+        <translation>Erreur d&apos;identité booléenne : la phrase la plus longue doit avoir un connecteur au point de différence.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity requires one (1) reference.</source>
+        <translation>Identité booléenne nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Boolean Negation Error: Expected complementary cancellation or constant negation.</source>
+        <translation>Erreur de négation booléenne : une annulation complémentaire ou une négation de constante était attendue.</translation>
+    </message>
+    <message>
+        <source>Boolean Negation requires one (1) reference.</source>
+        <translation>Négation booléenne nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Both of the left sentences must be the same.</source>
+        <translation>Les deux phrases de gauche doivent être identiques.</translation>
+    </message>
+    <message>
+        <source>Both sides of the conditional must be negated in the longer sentence.</source>
+        <translation>Les deux membres de la conditionnelle doivent être niés dans la phrase la plus longue.</translation>
+    </message>
+    <message>
+        <source>Bound Variable Substitution constructed incorrectly.</source>
+        <translation>Substitution de variable liée mal construite.</translation>
+    </message>
+    <message>
+        <source>Bound Variable constructed incorrectly.</source>
+        <translation>Variable liée mal construite.</translation>
+    </message>
+    <message>
+        <source>Bound Variable requires one (1) reference.</source>
+        <translation>Variable liée nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Commutativity constructed incorrectly.</source>
+        <translation>Commutativité mal construite.</translation>
+    </message>
+    <message>
+        <source>Commutativity requires one (1) reference.</source>
+        <translation>Commutativité nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Conjunction Error: The referenced conjuncts do not match the conclusion.</source>
+        <translation>Erreur de conjonction : les conjoints référencés ne correspondent pas à la conclusion.</translation>
+    </message>
+    <message>
+        <source>Conjunction requires at least two (2) references.</source>
+        <translation>Conjonction nécessite au moins deux (2) références.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma Error: The antecedents or consequences do not correspond to the conclusion&apos;s disjuncts.</source>
+        <translation>Erreur de dilemme constructif : les antécédents ou conséquents ne correspondent pas aux disjoints de la conclusion.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma Error: The structure of the conditionals or disjunctions does not match.</source>
+        <translation>Erreur de dilemme constructif : la structure des conditionnelles ou des disjonctions ne correspond pas.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma requires at least three (3) references.</source>
+        <translation>Dilemme constructif nécessite au moins trois (3) références.</translation>
+    </message>
+    <message>
+        <source>Contrapositive constructed incorrectly.</source>
+        <translation>Contraposée mal construite.</translation>
+    </message>
+    <message>
+        <source>Contrapositive requires one (1) reference.</source>
+        <translation>Contraposée nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>DeMorgan Error: Expected equivalence when distributing negation across conjunction or disjunction.</source>
+        <translation>Erreur de De Morgan : une équivalence était attendue lors de la distribution de la négation sur une conjonction ou une disjonction.</translation>
+    </message>
+    <message>
+        <source>DeMorgan Quantifier Error: Expected a quantifier on the negated statement.</source>
+        <translation>Erreur de quantificateur de De Morgan : un quantificateur était attendu sur l&apos;énoncé nié.</translation>
+    </message>
+    <message>
+        <source>DeMorgan constructed incorrectly.</source>
+        <translation>De Morgan mal construit.</translation>
+    </message>
+    <message>
+        <source>DeMorgan requires one (1) reference.</source>
+        <translation>De Morgan nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Disjunctive Syllogism Error: The referenced disjunction or negation does not match the conclusion.</source>
+        <translation>Erreur de syllogisme disjonctif : la disjonction ou la négation référencée ne correspond pas à la conclusion.</translation>
+    </message>
+    <message>
+        <source>Disjunctive Syllogism requires at least two (2) references.</source>
+        <translation>Syllogisme disjonctif nécessite au moins deux (2) références.</translation>
+    </message>
+    <message>
+        <source>Distribution Error: A universal quantifier is distributed over a conjunction, and an existential quantifier is distributed over a disjunction.</source>
+        <translation>Erreur de distribution : un quantificateur universel se distribue sur une conjonction, un quantificateur existentiel sur une disjonction.</translation>
+    </message>
+    <message>
+        <source>Distribution constructed incorrectly.</source>
+        <translation>Distribution mal construite.</translation>
+    </message>
+    <message>
+        <source>Distribution must be done around a conjunction or a disjunction.</source>
+        <translation>La distribution doit être effectuée autour d&apos;une conjonction ou d&apos;une disjonction.</translation>
+    </message>
+    <message>
+        <source>Distribution requires one (1) reference.</source>
+        <translation>Distribution nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Double Negation constructed incorrectly.</source>
+        <translation>Double négation mal construite.</translation>
+    </message>
+    <message>
+        <source>Double Negation must be used to eliminate negations.</source>
+        <translation>La double négation doit être utilisée pour éliminer des négations.</translation>
+    </message>
+    <message>
+        <source>Double Negation removes negations in pairs.</source>
+        <translation>La double négation supprime les négations par paires.</translation>
+    </message>
+    <message>
+        <source>Double Negation requires one (1) reference.</source>
+        <translation>Double Négation nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Equivalence constructed incorrectly.</source>
+        <translation>Équivalence mal construite.</translation>
+    </message>
+    <message>
+        <source>Equivalence requires one (1) reference.</source>
+        <translation>Équivalence nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Excluded Middle requires zero (0) references.</source>
+        <translation>Tiers exclu nécessite zéro (0) référence.</translation>
+    </message>
+    <message>
+        <source>Existential Generalization constructed incorrectly.</source>
+        <translation>Généralisation existentielle mal construite.</translation>
+    </message>
+    <message>
+        <source>Existential Generalization requires exactly one (1) reference.</source>
+        <translation>Généralisation existentielle nécessite exactement une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation Error: The instantiated variable must be completely new and not previously used in the proof.</source>
+        <translation>Erreur d&apos;instanciation existentielle : la variable instanciée doit être entièrement nouvelle et ne pas avoir été utilisée auparavant dans la preuve.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation constructed incorrectly.</source>
+        <translation>Instanciation existentielle mal construite.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation requires exactly one (1) reference.</source>
+        <translation>Instanciation existentielle nécessite exactement une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Exportation constructed incorrectly.</source>
+        <translation>Exportation mal construite.</translation>
+    </message>
+    <message>
+        <source>Exportation requires one (1) reference.</source>
+        <translation>Exportation nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>File Error: Unable to open or read the specified lemma file.</source>
+        <translation>Erreur de fichier : impossible d&apos;ouvrir ou de lire le fichier de lemme spécifié.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution Error: Neither premise&apos;s substitution matches the conclusion.</source>
+        <translation>Erreur de substitution de variable libre : la substitution d&apos;aucune des prémisses ne correspond à la conclusion.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution Error: The substitution does not match the conclusion.</source>
+        <translation>Erreur de substitution de variable libre : la substitution ne correspond pas à la conclusion.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution requires one or two (1 or 2) references.</source>
+        <translation>Substitution de variable libre nécessite une ou deux (1 ou 2) références.</translation>
+    </message>
+    <message>
+        <source>Hypothetical Syllogism requires at least two (2) references.</source>
+        <translation>Syllogisme hypothétique nécessite au moins deux (2) références.</translation>
+    </message>
+    <message>
+        <source>Idempotence constructed incorrectly.</source>
+        <translation>Idempotence mal construite.</translation>
+    </message>
+    <message>
+        <source>Idempotence requires one (1) reference.</source>
+        <translation>Idempotence nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Identity requires zero (0) references.</source>
+        <translation>Identité nécessite zéro (0) référence.</translation>
+    </message>
+    <message>
+        <source>Implication Error: Expected equivalence between a conditional (P -&gt; Q) and a disjunction (~P v Q).</source>
+        <translation>Erreur d&apos;implication : une équivalence était attendue entre une conditionnelle (P -&gt; Q) et une disjonction (~P v Q).</translation>
+    </message>
+    <message>
+        <source>Implication requires one (1) reference.</source>
+        <translation>Implication nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Induction Error: The base case or inductive step does not match the universal conclusion.</source>
+        <translation>Erreur d&apos;induction : le cas de base ou l&apos;étape inductive ne correspond pas à la conclusion universelle.</translation>
+    </message>
+    <message>
+        <source>Induction requires two (2) references.</source>
+        <translation>Induction nécessite deux (2) références.</translation>
+    </message>
+    <message>
+        <source>Internal error: this line could not be evaluated (out of memory).</source>
+        <translation>Erreur interne : cette ligne n&apos;a pas pu être évaluée (mémoire insuffisante).</translation>
+    </message>
+    <message>
+        <source>Invalid Reference: A referenced line has a syntax or evaluation error. First fix the error on that line.</source>
+        <translation>Référence invalide : une ligne référencée contient une erreur de syntaxe ou d&apos;évaluation. Corrigez d&apos;abord l&apos;erreur sur cette ligne.</translation>
+    </message>
+    <message>
+        <source>Invalid Reference: One or more referenced line numbers do not exist in this proof.</source>
+        <translation>Référence invalide : un ou plusieurs numéros de ligne référencés n&apos;existent pas dans cette preuve.</translation>
+    </message>
+    <message>
+        <source>Lemma Error: The number of references provided must exactly match the number of premises required by the lemma.</source>
+        <translation>Erreur de lemme : le nombre de références fournies doit correspondre exactement au nombre de prémisses requises par le lemme.</translation>
+    </message>
+    <message>
+        <source>Lemma Error: The referenced lemma does not match the premises or conclusion required by this line.</source>
+        <translation>Erreur de lemme : le lemme référencé ne correspond pas aux prémisses ou à la conclusion requises par cette ligne.</translation>
+    </message>
+    <message>
+        <source>Missing Rule: Please select a justification rule for this proof line.</source>
+        <translation>Règle manquante : veuillez sélectionner une règle de justification pour cette ligne de preuve.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: Neither the antecedent nor the consequence of the conditional matches the premise or conclusion. Check your references and line order.</source>
+        <translation>Erreur de Modus Ponens : ni l&apos;antécédent ni le conséquent de la conditionnelle ne correspond à la prémisse ou à la conclusion. Vérifiez vos références et l&apos;ordre des lignes.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: One of the references must be a conditional statement (-&gt;).</source>
+        <translation>Erreur de Modus Ponens : l&apos;une des références doit être une conditionnelle (-&gt;).</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: The antecedent of the conditional (-&gt;) does not match the minor premise reference.</source>
+        <translation>Erreur de Modus Ponens : l&apos;antécédent de la conditionnelle (-&gt;) ne correspond pas à la référence de la prémisse mineure.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: The consequence of the conditional (-&gt;) does not match the conclusion.</source>
+        <translation>Erreur de Modus Ponens : le conséquent de la conditionnelle (-&gt;) ne correspond pas à la conclusion.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens requires two (2) references.</source>
+        <translation>Modus Ponens nécessite deux (2) références.</translation>
+    </message>
+    <message>
+        <source>None of the goals from the proof matched up with the conclusion.</source>
+        <translation>Aucun des objectifs de la preuve ne correspondait à la conclusion.</translation>
+    </message>
+    <message>
+        <source>None of the references matched one of the proof premises.</source>
+        <translation>Aucune des références ne correspondait à l&apos;une des prémisses de la preuve.</translation>
+    </message>
+    <message>
+        <source>Null Quantification requires one (1) reference.</source>
+        <translation>Quantification nulle nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: Could not find a matching connective enclosing the quantifier.</source>
+        <translation>Erreur de quantificateur nul : impossible de trouver un connecteur correspondant englobant le quantificateur.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: Removing the quantifier does not produce a sentence matching the other line.</source>
+        <translation>Erreur de quantificateur nul : la suppression du quantificateur ne produit pas une phrase correspondant à l&apos;autre ligne.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: The point of difference must be a quantifier with no free occurrences of its variable.</source>
+        <translation>Erreur de quantificateur nul : le point de différence doit être un quantificateur dont la variable n&apos;a aucune occurrence libre.</translation>
+    </message>
+    <message>
+        <source>One of the antecedents did not match a disjunct from the reference.</source>
+        <translation>L&apos;un des antécédents ne correspondait à aucun disjoint de la référence.</translation>
+    </message>
+    <message>
+        <source>One of the conclusion&apos;s disjuncts did not match a consequence.</source>
+        <translation>L&apos;un des disjoints de la conclusion ne correspondait à aucun conséquent.</translation>
+    </message>
+    <message>
+        <source>One of the conjuncts in the conclusion does not match up with a reference.</source>
+        <translation>L&apos;un des conjoints de la conclusion ne correspond à aucune référence.</translation>
+    </message>
+    <message>
+        <source>One of the conjuncts in the reference must match the conclusion.</source>
+        <translation>L&apos;un des conjoints de la référence doit correspondre à la conclusion.</translation>
+    </message>
+    <message>
+        <source>One of the consequences did not match a disjunct from the conclusion.</source>
+        <translation>L&apos;un des conséquents ne correspondait à aucun disjoint de la conclusion.</translation>
+    </message>
+    <message>
+        <source>One of the consequences of a reference does not match an antecedent.</source>
+        <translation>Le conséquent de l&apos;une des références ne correspond à aucun antécédent.</translation>
+    </message>
+    <message>
+        <source>One of the disjuncts does not correspond to a reference or the conclusion.</source>
+        <translation>L&apos;un des disjoints ne correspond à aucune référence ni à la conclusion.</translation>
+    </message>
+    <message>
+        <source>One of the premises must contain an identity predicate.</source>
+        <translation>L&apos;une des prémisses doit contenir un prédicat d&apos;identité.</translation>
+    </message>
+    <message>
+        <source>One of the reference&apos;s disjuncts did not match an antecedent.</source>
+        <translation>L&apos;un des disjoints de la référence ne correspondait à aucun antécédent.</translation>
+    </message>
+    <message>
+        <source>One of the references does not match up with a conjunct in the conclusion.</source>
+        <translation>L&apos;une des références ne correspond à aucun conjoint de la conclusion.</translation>
+    </message>
+    <message>
+        <source>One of the references must contain an XOR as its top connective.</source>
+        <translation>L&apos;une des références doit contenir un OU exclusif comme connecteur principal.</translation>
+    </message>
+    <message>
+        <source>One of the references or conclusion does not match up with a disjunct.</source>
+        <translation>L&apos;une des références ou la conclusion ne correspond à aucun disjoint.</translation>
+    </message>
+    <message>
+        <source>One sentence must contain a disjunction.</source>
+        <translation>Une phrase doit contenir une disjonction.</translation>
+    </message>
+    <message>
+        <source>Only line 1 can be blank; subsequent blank lines are not allowed.</source>
+        <translation>Seule la ligne 1 peut être vide ; les lignes vides suivantes ne sont pas autorisées.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: Could not find a matching connective enclosing the quantifier.</source>
+        <translation>Erreur de prénexe : impossible de trouver un connecteur correspondant englobant le quantificateur.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: Moving the quantifier does not produce a sentence matching the other line.</source>
+        <translation>Erreur de prénexe : le déplacement du quantificateur ne produit pas une phrase correspondant à l&apos;autre ligne.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: The quantifier must be preceded by a connective for it to be moved.</source>
+        <translation>Erreur de prénexe : le quantificateur doit être précédé d&apos;un connecteur pour pouvoir être déplacé.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: The quantifier&apos;s scope must not be empty.</source>
+        <translation>Erreur de prénexe : la portée du quantificateur ne doit pas être vide.</translation>
+    </message>
+    <message>
+        <source>Prenex requires one (1) reference.</source>
+        <translation>Prénexe nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Rule &apos;sp&apos; (Subproof) can only reference the starting line of a subproof.</source>
+        <translation>La règle « sp » (sous-preuve) ne peut référencer que la ligne de début d&apos;une sous-preuve.</translation>
+    </message>
+    <message>
+        <source>Rule not recognized.</source>
+        <translation>Règle non reconnue.</translation>
+    </message>
+    <message>
+        <source>Sequence requires zero (0) references.</source>
+        <translation>Séquence nécessite zéro (0) référence.</translation>
+    </message>
+    <message>
+        <source>Simplification requires one (1) reference.</source>
+        <translation>Simplification nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Subproof Error: The premise of the subproof must match the conditional&apos;s antecedent, and the subproof conclusion must match the consequence.</source>
+        <translation>Erreur de sous-preuve : la prémisse de la sous-preuve doit correspondre à l&apos;antécédent de la conditionnelle, et la conclusion de la sous-preuve doit correspondre au conséquent.</translation>
+    </message>
+    <message>
+        <source>Subproof Error: The rule &apos;sp&apos; requires a subproof line as a reference.</source>
+        <translation>Erreur de sous-preuve : la règle « sp » nécessite une ligne de sous-preuve comme référence.</translation>
+    </message>
+    <message>
+        <source>Subsumption constructed incorrectly.</source>
+        <translation>Subsomption mal construite.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around a connective.</source>
+        <translation>La subsomption doit être effectuée autour d&apos;un connecteur.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around a disjunction or a conjunction.</source>
+        <translation>La subsomption doit être effectuée autour d&apos;une disjonction ou d&apos;une conjonction.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around two connectives.</source>
+        <translation>La subsomption doit être effectuée autour de deux connecteurs.</translation>
+    </message>
+    <message>
+        <source>Subsumption requires one (1) reference.</source>
+        <translation>Subsomption nécessite une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Symbol Negation Error: Expected negation of a Boolean constant symbol.</source>
+        <translation>Erreur de négation de symbole : la négation d&apos;un symbole de constante booléenne était attendue.</translation>
+    </message>
+    <message>
+        <source>Symbol Negation requires exactly one (1) reference.</source>
+        <translation>Négation de symbole nécessite exactement une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Chaining conditionals (-&gt;), biconditionals (&lt;-&gt;), or XOR without enclosing parentheses is ambiguous.</source>
+        <translation>Erreur de syntaxe : enchaîner des conditionnelles (-&gt;), des biconditionnelles (&lt;-&gt;) ou des OU exclusifs sans parenthèses englobantes est ambigu.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Individual terms and variables must start with a lowercase letter (a-z) or number.</source>
+        <translation>Erreur de syntaxe : les termes individuels et les variables doivent commencer par une minuscule (a-z) ou un chiffre.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Invalid characters in symbol name or empty argument parentheses &apos;()&apos;.</source>
+        <translation>Erreur de syntaxe : caractères invalides dans le nom du symbole ou parenthèses d&apos;arguments vides « () ».</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Mismatched parentheses. Check opening and closing brackets.</source>
+        <translation>Erreur de syntaxe : parenthèses non appariées. Vérifiez les crochets ouvrants et fermants.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Predicate or propositional variable names must start with an uppercase letter (A-Z).</source>
+        <translation>Erreur de syntaxe : les noms de prédicats ou de variables propositionnelles doivent commencer par une majuscule (A-Z).</translation>
+    </message>
+    <message>
+        <source>Syntax Error: The sentence has syntactical errors.</source>
+        <translation>Erreur de syntaxe : la phrase contient des erreurs syntaxiques.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Unrecognized or invalid logical connective symbol.</source>
+        <translation>Erreur de syntaxe : symbole de connecteur logique non reconnu ou invalide.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Unrecognized or invalid quantifier symbol.</source>
+        <translation>Erreur de syntaxe : symbole de quantificateur non reconnu ou invalide.</translation>
+    </message>
+    <message>
+        <source>The conclusion must contain an XOR.</source>
+        <translation>La conclusion doit contenir un OU exclusif.</translation>
+    </message>
+    <message>
+        <source>The conclusion must have an identity predicate.</source>
+        <translation>La conclusion doit comporter un prédicat d&apos;identité.</translation>
+    </message>
+    <message>
+        <source>The conclusion must start with a universal.</source>
+        <translation>La conclusion doit commencer par un quantificateur universel.</translation>
+    </message>
+    <message>
+        <source>The connective must be a conjunction or disjunction.</source>
+        <translation>Le connecteur doit être une conjonction ou une disjonction.</translation>
+    </message>
+    <message>
+        <source>The difference must be a bound variable.</source>
+        <translation>La différence doit être une variable liée.</translation>
+    </message>
+    <message>
+        <source>The difference must be a quantifier.</source>
+        <translation>La différence doit être un quantificateur.</translation>
+    </message>
+    <message>
+        <source>The final argument of the sequence&apos;s function must be the variable.</source>
+        <translation>Le dernier argument de la fonction de la séquence doit être la variable.</translation>
+    </message>
+    <message>
+        <source>The first argument must be a value function.</source>
+        <translation>Le premier argument doit être une fonction de valeur.</translation>
+    </message>
+    <message>
+        <source>The left disjunct must be the negation of the right disjunct.</source>
+        <translation>Le disjoint gauche doit être la négation du disjoint droit.</translation>
+    </message>
+    <message>
+        <source>The left disjunct must have a negation.</source>
+        <translation>Le disjoint gauche doit comporter une négation.</translation>
+    </message>
+    <message>
+        <source>The minor premise and conclusion do not match the XOR disjuncts correctly.</source>
+        <translation>La prémisse mineure et la conclusion ne correspondent pas correctement aux disjoints du OU exclusif.</translation>
+    </message>
+    <message>
+        <source>The negation sentence must be negating either a conjunction or a disjunction.</source>
+        <translation>La phrase niée doit nier soit une conjonction, soit une disjonction.</translation>
+    </message>
+    <message>
+        <source>The new variable did not appear in the conclusion.</source>
+        <translation>La nouvelle variable n&apos;apparaissait pas dans la conclusion.</translation>
+    </message>
+    <message>
+        <source>The quantifiers must be the same.</source>
+        <translation>Les quantificateurs doivent être identiques.</translation>
+    </message>
+    <message>
+        <source>The reference must be the first disjunct in the conclusion.</source>
+        <translation>La référence doit être le premier disjoint de la conclusion.</translation>
+    </message>
+    <message>
+        <source>The rest of the sentences must be the same.</source>
+        <translation>Le reste des phrases doit être identique.</translation>
+    </message>
+    <message>
+        <source>The second part must be the negation of the first.</source>
+        <translation>La seconde partie doit être la négation de la première.</translation>
+    </message>
+    <message>
+        <source>The sequence must only be used once.</source>
+        <translation>La séquence ne doit être utilisée qu&apos;une seule fois.</translation>
+    </message>
+    <message>
+        <source>The sequence variable must not have been used before.</source>
+        <translation>La variable de séquence ne doit pas avoir été utilisée auparavant.</translation>
+    </message>
+    <message>
+        <source>The top connective must change between sentences.</source>
+        <translation>Le connecteur principal doit changer entre les phrases.</translation>
+    </message>
+    <message>
+        <source>The two arguments to the identity predicate must be the same.</source>
+        <translation>Les deux arguments du prédicat d&apos;identité doivent être identiques.</translation>
+    </message>
+    <message>
+        <source>The two connectives must be complementary to one another.</source>
+        <translation>Les deux connecteurs doivent être complémentaires l&apos;un de l&apos;autre.</translation>
+    </message>
+    <message>
+        <source>The two references must match the two disjuncts of the XOR conclusion.</source>
+        <translation>Les deux références doivent correspondre aux deux disjoints de la conclusion en OU exclusif.</translation>
+    </message>
+    <message>
+        <source>The two sentences must be of different lengths.</source>
+        <translation>Les deux phrases doivent avoir des longueurs différentes.</translation>
+    </message>
+    <message>
+        <source>The variable must be the second argument of the value function.</source>
+        <translation>La variable doit être le second argument de la fonction de valeur.</translation>
+    </message>
+    <message>
+        <source>The variable must be used only twice.</source>
+        <translation>La variable ne doit être utilisée que deux fois.</translation>
+    </message>
+    <message>
+        <source>The variables must not appear in the scope.</source>
+        <translation>Les variables ne doivent pas apparaître dans la portée.</translation>
+    </message>
+    <message>
+        <source>There must be a biconditional in one sentence.</source>
+        <translation>Une phrase doit contenir une biconditionnelle.</translation>
+    </message>
+    <message>
+        <source>There must be a conditional in both sentences.</source>
+        <translation>Il doit y avoir une conditionnelle dans les deux phrases.</translation>
+    </message>
+    <message>
+        <source>There must be a conditional in the conclusion.</source>
+        <translation>La conclusion doit contenir une conditionnelle.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction in the conclusion.</source>
+        <translation>La conclusion doit contenir une conjonction.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction in the reference.</source>
+        <translation>La référence doit contenir une conjonction.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction or a disjunction at the difference.</source>
+        <translation>Il doit y avoir une conjonction ou une disjonction au point de différence.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction or a disjunction in one sentence.</source>
+        <translation>Il doit y avoir une conjonction ou une disjonction dans une phrase.</translation>
+    </message>
+    <message>
+        <source>There must be a connective at the difference.</source>
+        <translation>Il doit y avoir un connecteur au point de différence.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in both sentences.</source>
+        <translation>Il doit y avoir un connecteur dans les deux phrases.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in one sentence.</source>
+        <translation>Il doit y avoir un connecteur dans une phrase.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in the longer sentence.</source>
+        <translation>Il doit y avoir un connecteur dans la phrase la plus longue.</translation>
+    </message>
+    <message>
+        <source>There must be a disjunction in the conclusion.</source>
+        <translation>La conclusion doit contenir une disjonction.</translation>
+    </message>
+    <message>
+        <source>There must be a disjunction in the longest reference.</source>
+        <translation>La référence la plus longue doit contenir une disjonction.</translation>
+    </message>
+    <message>
+        <source>There must be a negated symbol in one sentence.</source>
+        <translation>Il doit y avoir un symbole nié dans une phrase.</translation>
+    </message>
+    <message>
+        <source>There must be a negation at the difference.</source>
+        <translation>Il doit y avoir une négation au point de différence.</translation>
+    </message>
+    <message>
+        <source>There must be a negation in one sentence.</source>
+        <translation>Il doit y avoir une négation dans une phrase.</translation>
+    </message>
+    <message>
+        <source>There must be a quantifier after the negation.</source>
+        <translation>Il doit y avoir un quantificateur après la négation.</translation>
+    </message>
+    <message>
+        <source>There must be a quantifier at the difference.</source>
+        <translation>Il doit y avoir un quantificateur au point de différence.</translation>
+    </message>
+    <message>
+        <source>There must be a tautology or a contradiction in the generalities.</source>
+        <translation>Il doit y avoir une tautologie ou une contradiction dans les généralités.</translation>
+    </message>
+    <message>
+        <source>There must be a tautology or a contradiction within the difference.</source>
+        <translation>Il doit y avoir une tautologie ou une contradiction au point de différence.</translation>
+    </message>
+    <message>
+        <source>There must be a universal at the beginning of the conclusion.</source>
+        <translation>Il doit y avoir un quantificateur universel au début de la conclusion.</translation>
+    </message>
+    <message>
+        <source>There must be an identity predicate in the scope.</source>
+        <translation>Il doit y avoir un prédicat d&apos;identité dans la portée.</translation>
+    </message>
+    <message>
+        <source>There must be connectives on both sentences.</source>
+        <translation>Il doit y avoir des connecteurs dans les deux phrases.</translation>
+    </message>
+    <message>
+        <source>There must be generalities at the difference.</source>
+        <translation>Il doit y avoir des généralités au point de différence.</translation>
+    </message>
+    <message>
+        <source>There must be generalities in the scope.</source>
+        <translation>Il doit y avoir des généralités dans la portée.</translation>
+    </message>
+    <message>
+        <source>There must be more than one generality for distribution.</source>
+        <translation>Il doit y avoir plus d&apos;une généralité pour la distribution.</translation>
+    </message>
+    <message>
+        <source>There must be only two connected parts.</source>
+        <translation>Il ne doit y avoir que deux parties connectées.</translation>
+    </message>
+    <message>
+        <source>There must be only two parts for distribution.</source>
+        <translation>Il ne doit y avoir que deux parties pour la distribution.</translation>
+    </message>
+    <message>
+        <source>There must be quantifiers at the difference.</source>
+        <translation>Il doit y avoir des quantificateurs au point de différence.</translation>
+    </message>
+    <message>
+        <source>Universal Generalization Error: The generalized variable must be arbitrary (not introduced by Existential Instantiation or unclosed assumptions).</source>
+        <translation>Erreur de généralisation universelle : la variable généralisée doit être arbitraire (non introduite par une instanciation existentielle ou des hypothèses non closes).</translation>
+    </message>
+    <message>
+        <source>Universal Generalization constructed incorrectly.</source>
+        <translation>Généralisation universelle mal construite.</translation>
+    </message>
+    <message>
+        <source>Universal Generalization requires exactly one (1) reference.</source>
+        <translation>Généralisation universelle nécessite exactement une (1) référence.</translation>
+    </message>
+    <message>
+        <source>Universal Instantiation constructed incorrectly.</source>
+        <translation>Instanciation universelle mal construite.</translation>
+    </message>
+    <message>
+        <source>Universal Instantiation requires exactly one (1) reference.</source>
+        <translation>Instanciation universelle nécessite exactement une (1) référence.</translation>
+    </message>
+    <message>
+        <source>XOR Elimination requires exactly two (2) references.</source>
+        <translation>Élimination de OU exclusif nécessite exactement deux (2) références.</translation>
+    </message>
+    <message>
+        <source>XOR Introduction requires exactly two (2) references.</source>
+        <translation>Introduction de OU exclusif nécessite exactement deux (2) références.</translation>
+    </message>
 </context>
 </TS>

--- a/qt/i18n/aris-qt_hu.ts
+++ b/qt/i18n/aris-qt_hu.ts
@@ -2,54 +2,33 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="hu_HU" sourcelanguage="en_US">
 <context>
-    <name>KeyGroup</name>
+    <name>Connector</name>
     <message>
-        <source>Conjunction</source>
-        <translation>Konjunkció</translation>
+        <location filename="../connector.cpp" line="415"/>
+        <source>Line %1 · %2: %3</source>
+        <translation>%1. sor · %2: %3</translation>
     </message>
     <message>
-        <source>Disjunction</source>
-        <translation>Diszjunkció</translation>
+        <location filename="../connector.cpp" line="481"/>
+        <source>File save failed for path: %1</source>
+        <translation>A fájl mentése sikertelen ezen az útvonalon: %1</translation>
     </message>
     <message>
-        <source>Negation</source>
-        <translation>Negáció</translation>
+        <location filename="../connector.cpp" line="514"/>
+        <source>File open failed for path: %1</source>
+        <translation>A fájl megnyitása sikertelen ezen az útvonalon: %1</translation>
     </message>
     <message>
-        <source>Implication</source>
-        <translation>Implikáció</translation>
+        <source>Evaluate Proof</source>
+        <translation>Bizonyítás kiértékelése</translation>
     </message>
     <message>
-        <source>Bi-conditional</source>
-        <translation>Ekvivalencia</translation>
+        <source>Correct!</source>
+        <translation>Helyes!</translation>
     </message>
     <message>
-        <source>For all</source>
-        <translation>Minden</translation>
-    </message>
-    <message>
-        <source>There exists</source>
-        <translation>Létezik</translation>
-    </message>
-    <message>
-        <source>Tautology</source>
-        <translation>Tautológia</translation>
-    </message>
-    <message>
-        <source>Contradiction</source>
-        <translation>Ellentmondás</translation>
-    </message>
-    <message>
-        <source>Belongs To</source>
-        <translation>Eleme</translation>
-    </message>
-    <message>
-        <source>Null</source>
-        <translation>Üres halmaz</translation>
-    </message>
-    <message>
-        <source>XOR</source>
-        <translation>Kizáró vagy</translation>
+        <source>Errors found</source>
+        <translation>Hibák találhatók</translation>
     </message>
 </context>
 <context>
@@ -70,381 +49,1469 @@
         <translation>Megnyitás</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="78"/>
+        <location filename="../DrawerTools.qml" line="77"/>
         <source>Save</source>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="97"/>
+        <location filename="../DrawerTools.qml" line="96"/>
         <source>Save As</source>
         <translation>Mentés másként</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="114"/>
         <source>Export To LaTeX</source>
-        <translation>Exportálás LaTeX-be</translation>
+        <translation type="vanished">Exportálás LaTeX-be</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="133"/>
+        <location filename="../DrawerTools.qml" line="107"/>
+        <source>Export</source>
+        <translation>Exportálás</translation>
+    </message>
+    <message>
+        <location filename="../DrawerTools.qml" line="122"/>
         <source>Toggle Goals</source>
         <translation>Célok be/ki</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="147"/>
+        <location filename="../DrawerTools.qml" line="136"/>
         <source>Toggle Dark Mode</source>
         <translation>Sötét mód be/ki</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="175"/>
+        <location filename="../DrawerTools.qml" line="164"/>
         <source>Zoom</source>
         <translation>Nagyítás</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="224"/>
+        <location filename="../DrawerTools.qml" line="213"/>
         <source>Reset Zoom</source>
         <translation>Betűméret visszaállítása</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="231"/>
+        <location filename="../DrawerTools.qml" line="220"/>
         <source>Paste Proof from Clipboard</source>
         <translation>Bizonyítás a vágólapra</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="237"/>
+        <location filename="../DrawerTools.qml" line="226"/>
         <source>(Ctrl+Shift+V)</source>
         <translation>(Ctrl+Shift+V)</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="246"/>
+        <location filename="../DrawerTools.qml" line="235"/>
         <source>Copy Selected Lines</source>
         <translation>A kiválasztott sorok másolása</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="252"/>
+        <location filename="../DrawerTools.qml" line="241"/>
         <source>(Ctrl+Shift+C)</source>
         <translation>(Ctrl-Shift+C)</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="261"/>
+        <location filename="../DrawerTools.qml" line="250"/>
         <source>Import Proof</source>
         <translation>Bizonyítás importja</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="273"/>
+        <location filename="../DrawerTools.qml" line="262"/>
         <source>Font</source>
         <translation>Betűtípus</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="283"/>
+        <location filename="../DrawerTools.qml" line="272"/>
         <source>Language</source>
         <translation>Nyelv</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="314"/>
+        <location filename="../DrawerTools.qml" line="315"/>
         <source>Help</source>
         <translation>Súgó</translation>
     </message>
     <message>
-        <location filename="../DrawerTools.qml" line="322"/>
+        <location filename="../DrawerTools.qml" line="323"/>
         <source>About</source>
         <translation>Névjegy</translation>
     </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Bizonyítás kiértékelése</translation>
+    </message>
 </context>
 <context>
-    <name>main</name>
+    <name>GoalLine</name>
     <message>
-        <location filename="../main.qml" line="145"/>
-        <source>QT_LAYOUT_DIRECTION</source>
-        <comment>QGuiApplication</comment>
-        <translation>LTR</translation>
+        <location filename="../GoalLine.qml" line="163"/>
+        <source>Invalid Operation: At least one goal line must remain.</source>
+        <translation>Érvénytelen művelet: legalább egy céltétel sornak meg kell maradnia.</translation>
+    </message>
+</context>
+<context>
+    <name>KeyGroup</name>
+    <message>
+        <location filename="../KeyGroup.qml" line="37"/>
+        <source>Conjunction</source>
+        <translation>Konjunkció</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="354"/>
-        <source>Unsaved changes</source>
-        <translation>Elmentetlen változtatások</translation>
+        <location filename="../KeyGroup.qml" line="44"/>
+        <source>Disjunction</source>
+        <translation>Diszjunkció</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
-        <source>Save file before closing?</source>
-        <translation>Mentés bezárás előtt?</translation>
+        <location filename="../KeyGroup.qml" line="51"/>
+        <source>Negation</source>
+        <translation>Negáció</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="383"/>
-        <source>Save new file before closing?</source>
-        <translation>Elmenti az új fájlt bezárás előtt?</translation>
+        <location filename="../KeyGroup.qml" line="58"/>
+        <source>Implication</source>
+        <translation>Implikáció</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="417"/>
-        <source>Reset the current proof and goals?</source>
-        <translation>Visszaállítja a jelenlegi bizonyítást és a célokat?</translation>
+        <location filename="../KeyGroup.qml" line="65"/>
+        <source>Bi-conditional</source>
+        <translation>Ekvivalencia</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="426"/>
-        <source>Cancel</source>
-        <translation>Mégsem</translation>
+        <location filename="../KeyGroup.qml" line="72"/>
+        <source>For all</source>
+        <translation>Minden</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
-        <source>Reset</source>
-        <translation>Visszaállítás</translation>
+        <location filename="../KeyGroup.qml" line="79"/>
+        <source>There exists</source>
+        <translation>Létezik</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="485"/>
-        <source>Choose import behavior</source>
-        <translation>Válasszon importálási módszert</translation>
+        <location filename="../KeyGroup.qml" line="86"/>
+        <source>Tautology</source>
+        <translation>Tautológia</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="494"/>
-        <source>Overwrite</source>
-        <translation>Felülírás</translation>
+        <location filename="../KeyGroup.qml" line="93"/>
+        <source>Contradiction</source>
+        <translation>Ellentmondás</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="506"/>
-        <source>Append End</source>
-        <translation>Hozzáfűzés a végéhez</translation>
+        <location filename="../KeyGroup.qml" line="100"/>
+        <source>Belongs To</source>
+        <translation>Eleme</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
-        <source>Prepend</source>
-        <translation>Beszúrás az elejére</translation>
+        <location filename="../KeyGroup.qml" line="107"/>
+        <source>Null</source>
+        <translation>Üres halmaz</translation>
+    </message>
+    <message>
+        <location filename="../KeyGroup.qml" line="114"/>
+        <source>XOR</source>
+        <translation>Kizáró vagy</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Bizonyítás kiértékelése</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>Helyes!</translation>
     </message>
 </context>
 <context>
     <name>ProofArea</name>
     <message>
-        <location filename="../ProofArea.qml" line="294"/>
+        <location filename="../ProofArea.qml" line="606"/>
         <source>Confirm Conversion</source>
         <translation>A konverzió megerősítése</translation>
     </message>
     <message>
-        <location filename="../ProofArea.qml" line="311"/>
+        <location filename="../ProofArea.qml" line="623"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../ProofArea.qml" line="323"/>
+        <location filename="../ProofArea.qml" line="635"/>
         <source>Convert Anyway</source>
         <translation>Konverzió mindenképp</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="439"/>
         <source>Convert</source>
         <translation>Konverzió</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="226"/>
+        <location filename="../ProofArea.qml" line="261"/>
+        <location filename="../ProofArea.qml" line="285"/>
+        <location filename="../ProofArea.qml" line="313"/>
+        <location filename="../ProofArea.qml" line="353"/>
+        <source>No line selected.</source>
+        <translation>Nincs kijelölt sor.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="362"/>
+        <source>Cannot convert structural subproof lines.</source>
+        <translation>A szerkezeti al-bizonyítás sorok nem konvertálhatók.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="369"/>
+        <source>Proof must contain at least one premise.</source>
+        <translation>A bizonyításnak legalább egy premisszát kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="441"/>
+        <location filename="../ProofArea.qml" line="1448"/>
         <source>Convert to Conclusion</source>
         <translation>Konklúzióvá konvertálás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="441"/>
+        <location filename="../ProofArea.qml" line="1448"/>
         <source>Convert to Premise</source>
         <translation>Premisszává konvertálás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="480"/>
         <source>Add Premise Above</source>
         <translation>Premissza beszúrása felülre</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="498"/>
         <source>Add Conclusion Below</source>
         <translation>Konklúzió beszúrása alulra</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="517"/>
+        <source>Add Comment Below</source>
+        <translation>Megjegyzés beszúrása alulra</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="869"/>
+        <source>Expand subproof</source>
+        <translation>Al-bizonyítás kibontása</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="869"/>
+        <source>Collapse subproof</source>
+        <translation>Al-bizonyítás összecsukása</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="901"/>
+        <source>Invalid Operation: A proof line can only reference earlier line numbers.</source>
+        <translation>Érvénytelen művelet: egy bizonyítási sor csak korábbi sorszámokra hivatkozhat.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="906"/>
+        <source>Invalid Operation: Cannot assign inference rules or references to a premise.</source>
+        <translation>Érvénytelen művelet: premisszához nem rendelhető következtetési szabály vagy hivatkozás.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="912"/>
+        <source>Invalid Operation: Cannot modify or reference the start line of a subproof directly.</source>
+        <translation>Érvénytelen művelet: egy al-bizonyítás kezdősora közvetlenül nem módosítható vagy hivatkozható.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="919"/>
+        <source>Invalid Operation: Cannot reference lines across closed subproof boundaries.</source>
+        <translation>Érvénytelen művelet: lezárt al-bizonyítás határain át nem hivatkozhatók sorok.</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1404"/>
         <source>Add Premise</source>
         <translation>Premissza hozzáadása</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1418"/>
         <source>Add Conclusion</source>
         <translation>Konklúzió hozzáadása</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1434"/>
+        <source>Add Comment</source>
+        <translation>Megjegyzés hozzáadása</translation>
+    </message>
+    <message>
+        <location filename="../ProofArea.qml" line="1484"/>
         <source>Start Subproof</source>
         <translation>Al-bizonyítás kezdete</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1498"/>
         <source>End Subproof</source>
         <translation>Al-bizonyítás vége</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1516"/>
         <source>Remove this Line</source>
         <translation>Törölje ezt a sort</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1172"/>
         <source>premise</source>
         <translation>premissza</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1173"/>
         <source>subproof</source>
         <translation>al-bizonyítás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="1174"/>
         <source>sf</source>
         <translation>ab</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
         <source>Inference</source>
         <translation>Következtetés</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Equivalence</source>
         <translation>Ekvivalencia</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
         <source>Predicate</source>
         <translation>Predikátum</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
         <source>Miscellaneous</source>
         <translation>Egyéb</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="114"/>
         <source>Boolean</source>
         <translation>Logikai</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Modus Ponens</source>
         <translation>Modus ponens</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Addition</source>
         <translation>Hozzáadás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Simplification</source>
         <translation>Egyszerűsítés</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Conjunction</source>
         <translation>Konjunkció</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Hypothetical Syllogism</source>
         <translation>Hipotetikus szillogizmus</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Disjunctive Syllogism</source>
         <translation>Diszjunktív szillogizmus</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Excluded middle</source>
         <translation>Kizárt harmadik</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>Constructive Dilemma</source>
         <translation>Konstruktív dilemma</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>XOR Introduction</source>
         <translation>Kizáró vagy eleje</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="119"/>
         <source>XOR Elimination</source>
         <translation>Kizáró vagy elhagyása</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Implication</source>
         <translation>Implikáció</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>DeMorgan</source>
         <translation>De Morgan</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Association</source>
         <translation>Asszociativitás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Commutativity</source>
         <translation>Kommutativitás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Idempotence</source>
         <translation>Idempotencia</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Distribution</source>
         <translation>Disztributivitás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Double Negation</source>
         <translation>Kettős tagadás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Exportation</source>
         <translation>Exportálás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Subsumption</source>
         <translation>Egybefoglalás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="120"/>
         <source>Contrapositive</source>
         <translation>Kontrapozíció</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Universal Generalization</source>
         <translation>Unverzális általánosítás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Universal Instantiation</source>
         <translation>Univerzális specifikáció</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Existential Generalization</source>
         <translation>Egzisztenciális általánosítás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Existential Instantiation</source>
         <translation>Egzisztenciális specifikáció</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Bound Variable Substitution</source>
         <translation>Kötött változó helyettesítés</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Null Quantifier</source>
         <translation>Nullkvantor</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Prenex</source>
         <translation>Prenex</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Identity</source>
         <translation>Identitás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="121"/>
         <source>Free Variable Substitution</source>
         <translation>Szabad változó helyettesítés</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="122"/>
         <source>Lemma</source>
         <translation>Lemma</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="122"/>
         <source>Subproof</source>
         <translation>Al-bizonyítás</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="122"/>
         <source>Sequence</source>
         <translation>Sorozat</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="122"/>
         <source>Induction</source>
         <translation>Indukció</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="123"/>
         <source>Identity </source>
         <translation>Identitás </translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="123"/>
         <source>Negation</source>
         <translation>Negáció</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="123"/>
         <source>Dominance</source>
         <translation>Dominancia</translation>
     </message>
     <message>
+        <location filename="../ProofArea.qml" line="123"/>
         <source>Symbol Negation</source>
         <translation>Tagadás szimbólum</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Bizonyítás kiértékelése</translation>
+    </message>
+</context>
+<context>
+    <name>auxConnector</name>
+    <message>
+        <location filename="../auxconnector.cpp" line="122"/>
+        <source>LaTeX export failed: could not convert proof to LaTeX format.</source>
+        <translation>A LaTeX-exportálás sikertelen: a bizonyítás nem alakítható át LaTeX formátumra.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="165"/>
+        <source>Import failed: the selected file could not be opened or is not a valid Aris proof.</source>
+        <translation>Az importálás sikertelen: a kiválasztott fájl nem nyitható meg, vagy nem érvényes Aris-bizonyítás.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="481"/>
+        <source>Text export failed: could not open &apos;%1&apos; for writing.</source>
+        <translation>A szöveges exportálás sikertelen: „%1” nem nyitható meg írásra.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="551"/>
+        <source>Markdown export failed: could not open &apos;%1&apos; for writing.</source>
+        <translation>A Markdown-exportálás sikertelen: „%1” nem nyitható meg írásra.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="855"/>
+        <source>ODT export failed: could not write to &apos;%1&apos;.</source>
+        <translation>Az ODT-exportálás sikertelen: nem írható „%1”.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="896"/>
+        <source>PDF export is not available on your device.</source>
+        <translation>A PDF-exportálás nem érhető el ezen az eszközön.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="915"/>
+        <source>PDF export failed: could not write to &apos;%1&apos;.</source>
+        <translation>A PDF-exportálás sikertelen: nem írható „%1”.</translation>
+    </message>
+    <message>
+        <location filename="../auxconnector.cpp" line="933"/>
+        <source>PDF export is not available in the browser version.</source>
+        <translation>A PDF-exportálás nem érhető el a böngészős verzióban.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../main.qml" line="166"/>
+        <source>Got it</source>
+        <translation>Rendben</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="201"/>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>QGuiApplication</comment>
+        <translation>LTR</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="563"/>
+        <source>Unsaved changes</source>
+        <translation>Elmentetlen változtatások</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="593"/>
+        <source>Save file before closing?</source>
+        <translation>Mentés bezárás előtt?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
+        <source>Save new file before closing?</source>
+        <translation>Elmenti az új fájlt bezárás előtt?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="628"/>
+        <source>Reset the current proof and goals?</source>
+        <translation>Visszaállítja a jelenlegi bizonyítást és a célokat?</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="637"/>
+        <location filename="../main.qml" line="1093"/>
+        <source>Cancel</source>
+        <translation>Mégsem</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="649"/>
+        <source>Reset</source>
+        <translation>Visszaállítás</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="696"/>
+        <source>Choose import behavior</source>
+        <translation>Válasszon importálási módszert</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="705"/>
+        <source>Overwrite</source>
+        <translation>Felülírás</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="717"/>
+        <source>Append End</source>
+        <translation>Hozzáfűzés a végéhez</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="729"/>
+        <source>Prepend</source>
+        <translation>Beszúrás az elejére</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="774"/>
+        <source>Choose export format</source>
+        <translation>Exportálási formátum kiválasztása</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="783"/>
+        <source>LaTeX</source>
+        <translation>LaTeX</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="799"/>
+        <source>Plain Text</source>
+        <translation>Egyszerű szöveg</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="815"/>
+        <source>Markdown</source>
+        <translation>Markdown</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="869"/>
+        <source>Choose save format</source>
+        <translation>Mentési formátum kiválasztása</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="881"/>
+        <source>Aris (.tle)</source>
+        <translation>Aris (.tle)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="904"/>
+        <source>ODT (.odt)</source>
+        <translation>ODT (.odt)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="926"/>
+        <source>PDF (.pdf)</source>
+        <translation>PDF (.pdf)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1014"/>
+        <source>Jump to Line</source>
+        <translation>Ugrás sorra</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1026"/>
+        <source>Invalid line number. Must be between 1 and </source>
+        <translation>Érvénytelen sorszám. 1 és a következő között kell lennie: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1054"/>
+        <source>Line number</source>
+        <translation>Sorszám</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1103"/>
+        <source>Jump</source>
+        <translation>Ugrás</translation>
+    </message>
+    <message>
+        <source>Evaluate Proof</source>
+        <translation>Bizonyítás kiértékelése</translation>
+    </message>
+    <message>
+        <source>Correct!</source>
+        <translation>Helyes!</translation>
+    </message>
+    <message>
+        <source>Errors found</source>
+        <translation>Hibák találhatók</translation>
+    </message>
+    <message>
+        <source>Errors found — see inline details above each failing line.</source>
+        <translation>Hibák találhatók – a részletek az egyes hibás sorok felett láthatók.</translation>
+    </message>
+</context>
+<context>
+    <name>ProofErrors</name>
+    <message>
+        <source>A proof must be specified.</source>
+        <translation>Meg kell adni egy bizonyítást.</translation>
+    </message>
+    <message>
+        <source>A tautology must be matched with a conjunction, and a contradiction with a disjunction.</source>
+        <translation>A tautológiának konjunkcióval, az ellentmondásnak diszjunkcióval kell egyeznie.</translation>
+    </message>
+    <message>
+        <source>Addition requires one (1) reference.</source>
+        <translation>A hozzáadás egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>All of the references except the disjunction reference must contain a conditional.</source>
+        <translation>A diszjunkcióra hivatkozó sor kivételével minden hivatkozásnak kondicionálist kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>All of the references must be used.</source>
+        <translation>Minden hivatkozást fel kell használni.</translation>
+    </message>
+    <message>
+        <source>All of the references must contain a conditional.</source>
+        <translation>Minden hivatkozásnak kondicionálist kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>Association constructed incorrectly.</source>
+        <translation>Az asszociativitás hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Association must be done on a conjunction or disjunction.</source>
+        <translation>Az asszociativitást konjunkción vagy diszjunkción kell elvégezni.</translation>
+    </message>
+    <message>
+        <source>Association requires one (1) reference.</source>
+        <translation>Az asszociativitás egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Boolean Dominance Error: Expected absorption with True/False constants.</source>
+        <translation>Logikai dominancia hiba: elnyelést vártunk az Igaz/Hamis konstansokkal.</translation>
+    </message>
+    <message>
+        <source>Boolean Domination requires one (1) reference.</source>
+        <translation>A logikai dominancia egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: Could not align the longer sentence&apos;s structure with the point of difference.</source>
+        <translation>Logikai identitás hiba: a hosszabb formula szerkezete nem illeszthető a különbség helyéhez.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: Simplifying or expanding the True/False constant does not produce a sentence matching the other line.</source>
+        <translation>Logikai identitás hiba: az Igaz/Hamis konstans egyszerűsítése vagy kibővítése nem eredményez a másik sorral egyező formulát.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: The difference must be enclosed by a connective, not at the very start of the sentence.</source>
+        <translation>Logikai identitás hiba: a különbségnek egy kötőjel által körülvéve kell lennie, nem a formula legelején.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity Error: The longer sentence must have a connective at the point of difference.</source>
+        <translation>Logikai identitás hiba: a hosszabb formulának kötőjelet kell tartalmaznia a különbség helyén.</translation>
+    </message>
+    <message>
+        <source>Boolean Identity requires one (1) reference.</source>
+        <translation>A logikai identitás egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Boolean Negation Error: Expected complementary cancellation or constant negation.</source>
+        <translation>Logikai negáció hiba: komplementer kiejtést vagy konstans tagadását vártunk.</translation>
+    </message>
+    <message>
+        <source>Boolean Negation requires one (1) reference.</source>
+        <translation>A logikai negáció egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Both of the left sentences must be the same.</source>
+        <translation>A két bal oldali formulának meg kell egyeznie.</translation>
+    </message>
+    <message>
+        <source>Both sides of the conditional must be negated in the longer sentence.</source>
+        <translation>A hosszabb formulában a kondicionális mindkét oldalát tagadni kell.</translation>
+    </message>
+    <message>
+        <source>Bound Variable Substitution constructed incorrectly.</source>
+        <translation>A kötött változó helyettesítés hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Bound Variable constructed incorrectly.</source>
+        <translation>A kötött változó hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Bound Variable requires one (1) reference.</source>
+        <translation>A kötött változó egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Commutativity constructed incorrectly.</source>
+        <translation>A kommutativitás hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Commutativity requires one (1) reference.</source>
+        <translation>A kommutativitás egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Conjunction Error: The referenced conjuncts do not match the conclusion.</source>
+        <translation>Konjunkció hiba: a hivatkozott konjunktumok nem egyeznek a konklúzióval.</translation>
+    </message>
+    <message>
+        <source>Conjunction requires at least two (2) references.</source>
+        <translation>A konjunkció legalább két (2) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma Error: The antecedents or consequences do not correspond to the conclusion&apos;s disjuncts.</source>
+        <translation>Konstruktív dilemma hiba: az előtagok vagy utótagok nem felelnek meg a konklúzió diszjunktumainak.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma Error: The structure of the conditionals or disjunctions does not match.</source>
+        <translation>Konstruktív dilemma hiba: a kondicionálisok vagy diszjunkciók szerkezete nem egyezik.</translation>
+    </message>
+    <message>
+        <source>Constructive Dilemma requires at least three (3) references.</source>
+        <translation>A konstruktív dilemma legalább három (3) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Contrapositive constructed incorrectly.</source>
+        <translation>A kontrapozíció hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Contrapositive requires one (1) reference.</source>
+        <translation>A kontrapozíció egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>DeMorgan Error: Expected equivalence when distributing negation across conjunction or disjunction.</source>
+        <translation>De Morgan hiba: ekvivalenciát vártunk a tagadás konjunkción vagy diszjunkción történő szétosztásakor.</translation>
+    </message>
+    <message>
+        <source>DeMorgan Quantifier Error: Expected a quantifier on the negated statement.</source>
+        <translation>De Morgan kvantor hiba: a tagadott állításon kvantort vártunk.</translation>
+    </message>
+    <message>
+        <source>DeMorgan constructed incorrectly.</source>
+        <translation>A De Morgan hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>DeMorgan requires one (1) reference.</source>
+        <translation>A De Morgan egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Disjunctive Syllogism Error: The referenced disjunction or negation does not match the conclusion.</source>
+        <translation>Diszjunktív szillogizmus hiba: a hivatkozott diszjunkció vagy tagadás nem egyezik a konklúzióval.</translation>
+    </message>
+    <message>
+        <source>Disjunctive Syllogism requires at least two (2) references.</source>
+        <translation>A diszjunktív szillogizmus legalább két (2) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Distribution Error: A universal quantifier is distributed over a conjunction, and an existential quantifier is distributed over a disjunction.</source>
+        <translation>Disztributivitás hiba: az univerzális kvantor konjunkción, az egzisztenciális kvantor diszjunkción osztódik szét.</translation>
+    </message>
+    <message>
+        <source>Distribution constructed incorrectly.</source>
+        <translation>A disztributivitás hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Distribution must be done around a conjunction or a disjunction.</source>
+        <translation>A disztributivitást konjunkció vagy diszjunkció körül kell elvégezni.</translation>
+    </message>
+    <message>
+        <source>Distribution requires one (1) reference.</source>
+        <translation>A disztributivitás egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Double Negation constructed incorrectly.</source>
+        <translation>A kettős tagadás hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Double Negation must be used to eliminate negations.</source>
+        <translation>A kettős tagadást tagadások megszüntetésére kell használni.</translation>
+    </message>
+    <message>
+        <source>Double Negation removes negations in pairs.</source>
+        <translation>A kettős tagadás párosával távolítja el a tagadásokat.</translation>
+    </message>
+    <message>
+        <source>Double Negation requires one (1) reference.</source>
+        <translation>A kettős tagadás egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Equivalence constructed incorrectly.</source>
+        <translation>Az ekvivalencia hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Equivalence requires one (1) reference.</source>
+        <translation>Az ekvivalencia egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Excluded Middle requires zero (0) references.</source>
+        <translation>A kizárt harmadik nulla (0) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Existential Generalization constructed incorrectly.</source>
+        <translation>Az egzisztenciális általánosítás hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Existential Generalization requires exactly one (1) reference.</source>
+        <translation>Az egzisztenciális általánosítás pontosan egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation Error: The instantiated variable must be completely new and not previously used in the proof.</source>
+        <translation>Egzisztenciális specifikáció hiba: a specifikált változónak teljesen újnak kell lennie, és korábban nem szabad használni a bizonyításban.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation constructed incorrectly.</source>
+        <translation>Az egzisztenciális specifikáció hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Existential Instantiation requires exactly one (1) reference.</source>
+        <translation>Az egzisztenciális specifikáció pontosan egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Exportation constructed incorrectly.</source>
+        <translation>Az exportálás hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Exportation requires one (1) reference.</source>
+        <translation>Az exportálás egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>File Error: Unable to open or read the specified lemma file.</source>
+        <translation>Fájlhiba: a megadott lemmafájl nem nyitható meg vagy nem olvasható.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution Error: Neither premise&apos;s substitution matches the conclusion.</source>
+        <translation>Szabad változó helyettesítés hiba: egyik premissza helyettesítése sem egyezik a konklúzióval.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution Error: The substitution does not match the conclusion.</source>
+        <translation>Szabad változó helyettesítés hiba: a helyettesítés nem egyezik a konklúzióval.</translation>
+    </message>
+    <message>
+        <source>Free Variable Substitution requires one or two (1 or 2) references.</source>
+        <translation>A szabad változó helyettesítés egy vagy két (1 vagy 2) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Hypothetical Syllogism requires at least two (2) references.</source>
+        <translation>A hipotetikus szillogizmus legalább két (2) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Idempotence constructed incorrectly.</source>
+        <translation>Az idempotencia hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Idempotence requires one (1) reference.</source>
+        <translation>Az idempotencia egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Identity requires zero (0) references.</source>
+        <translation>Az identitás nulla (0) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Implication Error: Expected equivalence between a conditional (P -&gt; Q) and a disjunction (~P v Q).</source>
+        <translation>Implikáció hiba: ekvivalenciát vártunk egy kondicionális (P -&gt; Q) és egy diszjunkció (~P v Q) között.</translation>
+    </message>
+    <message>
+        <source>Implication requires one (1) reference.</source>
+        <translation>Az implikáció egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Induction Error: The base case or inductive step does not match the universal conclusion.</source>
+        <translation>Indukció hiba: az alapeset vagy az indukciós lépés nem egyezik az univerzális konklúzióval.</translation>
+    </message>
+    <message>
+        <source>Induction requires two (2) references.</source>
+        <translation>Az indukció két (2) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Internal error: this line could not be evaluated (out of memory).</source>
+        <translation>Belső hiba: ez a sor nem értékelhető ki (elfogyott a memória).</translation>
+    </message>
+    <message>
+        <source>Invalid Reference: A referenced line has a syntax or evaluation error. First fix the error on that line.</source>
+        <translation>Érvénytelen hivatkozás: egy hivatkozott sor szintaktikai vagy kiértékelési hibát tartalmaz. Először javítsa ki a hibát azon a sorban.</translation>
+    </message>
+    <message>
+        <source>Invalid Reference: One or more referenced line numbers do not exist in this proof.</source>
+        <translation>Érvénytelen hivatkozás: egy vagy több hivatkozott sorszám nem létezik ebben a bizonyításban.</translation>
+    </message>
+    <message>
+        <source>Lemma Error: The number of references provided must exactly match the number of premises required by the lemma.</source>
+        <translation>Lemma hiba: a megadott hivatkozások számának pontosan meg kell egyeznie a lemma által igényelt premisszák számával.</translation>
+    </message>
+    <message>
+        <source>Lemma Error: The referenced lemma does not match the premises or conclusion required by this line.</source>
+        <translation>Lemma hiba: a hivatkozott lemma nem egyezik az ehhez a sorhoz szükséges premisszákkal vagy konklúzióval.</translation>
+    </message>
+    <message>
+        <source>Missing Rule: Please select a justification rule for this proof line.</source>
+        <translation>Hiányzó szabály: válasszon indoklási szabályt ehhez a bizonyítási sorhoz.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: Neither the antecedent nor the consequence of the conditional matches the premise or conclusion. Check your references and line order.</source>
+        <translation>Modus ponens hiba: sem a kondicionális előtagja, sem az utótagja nem egyezik a premisszával vagy a konklúzióval. Ellenőrizze a hivatkozásokat és a sorok sorrendjét.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: One of the references must be a conditional statement (-&gt;).</source>
+        <translation>Modus ponens hiba: az egyik hivatkozásnak kondicionális állításnak (-&gt;) kell lennie.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: The antecedent of the conditional (-&gt;) does not match the minor premise reference.</source>
+        <translation>Modus ponens hiba: a kondicionális (-&gt;) előtagja nem egyezik a kishivatkozott premisszával.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens Error: The consequence of the conditional (-&gt;) does not match the conclusion.</source>
+        <translation>Modus ponens hiba: a kondicionális (-&gt;) utótagja nem egyezik a konklúzióval.</translation>
+    </message>
+    <message>
+        <source>Modus Ponens requires two (2) references.</source>
+        <translation>A Modus ponens két (2) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>None of the goals from the proof matched up with the conclusion.</source>
+        <translation>A bizonyítás egyik célja sem egyezett a konklúzióval.</translation>
+    </message>
+    <message>
+        <source>None of the references matched one of the proof premises.</source>
+        <translation>Egyik hivatkozás sem egyezett a bizonyítás egyik premisszájával sem.</translation>
+    </message>
+    <message>
+        <source>Null Quantification requires one (1) reference.</source>
+        <translation>A nullkvantifikáció egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: Could not find a matching connective enclosing the quantifier.</source>
+        <translation>Nullkvantor hiba: nem található a kvantort körülölelő megfelelő kötőjel.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: Removing the quantifier does not produce a sentence matching the other line.</source>
+        <translation>Nullkvantor hiba: a kvantor eltávolítása nem eredményez a másik sorral egyező formulát.</translation>
+    </message>
+    <message>
+        <source>Null Quantifier Error: The point of difference must be a quantifier with no free occurrences of its variable.</source>
+        <translation>Nullkvantor hiba: a különbség helyén olyan kvantornak kell lennie, amelynek változója sehol nem fordul elő szabadon.</translation>
+    </message>
+    <message>
+        <source>One of the antecedents did not match a disjunct from the reference.</source>
+        <translation>Az egyik előtag a hivatkozás egyik diszjunktumával sem egyezett.</translation>
+    </message>
+    <message>
+        <source>One of the conclusion&apos;s disjuncts did not match a consequence.</source>
+        <translation>A konklúzió egyik diszjunktuma egyik utótaggal sem egyezett.</translation>
+    </message>
+    <message>
+        <source>One of the conjuncts in the conclusion does not match up with a reference.</source>
+        <translation>A konklúzió egyik konjunktuma nem egyezik egyik hivatkozással sem.</translation>
+    </message>
+    <message>
+        <source>One of the conjuncts in the reference must match the conclusion.</source>
+        <translation>A hivatkozás egyik konjunktumának egyeznie kell a konklúzióval.</translation>
+    </message>
+    <message>
+        <source>One of the consequences did not match a disjunct from the conclusion.</source>
+        <translation>Az egyik utótag a konklúzió egyik diszjunktumával sem egyezett.</translation>
+    </message>
+    <message>
+        <source>One of the consequences of a reference does not match an antecedent.</source>
+        <translation>Az egyik hivatkozás utótagja egyik előtaggal sem egyezik.</translation>
+    </message>
+    <message>
+        <source>One of the disjuncts does not correspond to a reference or the conclusion.</source>
+        <translation>Az egyik diszjunktum nem felel meg egyik hivatkozásnak vagy a konklúziónak sem.</translation>
+    </message>
+    <message>
+        <source>One of the premises must contain an identity predicate.</source>
+        <translation>Az egyik premisszának identitáspredikátumot kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>One of the reference&apos;s disjuncts did not match an antecedent.</source>
+        <translation>A hivatkozás egyik diszjunktuma egyik előtaggal sem egyezett.</translation>
+    </message>
+    <message>
+        <source>One of the references does not match up with a conjunct in the conclusion.</source>
+        <translation>Az egyik hivatkozás nem egyezik a konklúzió egyik konjunktumával sem.</translation>
+    </message>
+    <message>
+        <source>One of the references must contain an XOR as its top connective.</source>
+        <translation>Az egyik hivatkozásnak kizáró vagy-t kell tartalmaznia legfelső kötőjelként.</translation>
+    </message>
+    <message>
+        <source>One of the references or conclusion does not match up with a disjunct.</source>
+        <translation>Az egyik hivatkozás vagy a konklúzió nem egyezik egyik diszjunktummal sem.</translation>
+    </message>
+    <message>
+        <source>One sentence must contain a disjunction.</source>
+        <translation>Az egyik formulának diszjunkciót kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>Only line 1 can be blank; subsequent blank lines are not allowed.</source>
+        <translation>Csak az 1. sor lehet üres; az azt követő üres sorok nem megengedettek.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: Could not find a matching connective enclosing the quantifier.</source>
+        <translation>Prenex hiba: nem található a kvantort körülölelő megfelelő kötőjel.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: Moving the quantifier does not produce a sentence matching the other line.</source>
+        <translation>Prenex hiba: a kvantor áthelyezése nem eredményez a másik sorral egyező formulát.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: The quantifier must be preceded by a connective for it to be moved.</source>
+        <translation>Prenex hiba: a kvantor előtt kötőjelnek kell állnia ahhoz, hogy áthelyezhető legyen.</translation>
+    </message>
+    <message>
+        <source>Prenex Error: The quantifier&apos;s scope must not be empty.</source>
+        <translation>Prenex hiba: a kvantor hatóköre nem lehet üres.</translation>
+    </message>
+    <message>
+        <source>Prenex requires one (1) reference.</source>
+        <translation>A prenex egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Rule &apos;sp&apos; (Subproof) can only reference the starting line of a subproof.</source>
+        <translation>Az „sp” (al-bizonyítás) szabály csak egy al-bizonyítás kezdősorára hivatkozhat.</translation>
+    </message>
+    <message>
+        <source>Rule not recognized.</source>
+        <translation>A szabály nem ismert fel.</translation>
+    </message>
+    <message>
+        <source>Sequence requires zero (0) references.</source>
+        <translation>A sorozat nulla (0) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Simplification requires one (1) reference.</source>
+        <translation>Az egyszerűsítés egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Subproof Error: The premise of the subproof must match the conditional&apos;s antecedent, and the subproof conclusion must match the consequence.</source>
+        <translation>Al-bizonyítás hiba: az al-bizonyítás premisszájának egyeznie kell a kondicionális előtagjával, az al-bizonyítás konklúziójának pedig az utótaggal.</translation>
+    </message>
+    <message>
+        <source>Subproof Error: The rule &apos;sp&apos; requires a subproof line as a reference.</source>
+        <translation>Al-bizonyítás hiba: az „sp” szabály al-bizonyítás sort igényel hivatkozásként.</translation>
+    </message>
+    <message>
+        <source>Subsumption constructed incorrectly.</source>
+        <translation>Az egybefoglalás hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around a connective.</source>
+        <translation>Az egybefoglalást egy kötőjel körül kell elvégezni.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around a disjunction or a conjunction.</source>
+        <translation>Az egybefoglalást diszjunkció vagy konjunkció körül kell elvégezni.</translation>
+    </message>
+    <message>
+        <source>Subsumption must be done around two connectives.</source>
+        <translation>Az egybefoglalást két kötőjel körül kell elvégezni.</translation>
+    </message>
+    <message>
+        <source>Subsumption requires one (1) reference.</source>
+        <translation>Az egybefoglalás egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Symbol Negation Error: Expected negation of a Boolean constant symbol.</source>
+        <translation>Tagadás szimbólum hiba: egy logikai konstansszimbólum tagadását vártuk.</translation>
+    </message>
+    <message>
+        <source>Symbol Negation requires exactly one (1) reference.</source>
+        <translation>A tagadás szimbólum pontosan egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Chaining conditionals (-&gt;), biconditionals (&lt;-&gt;), or XOR without enclosing parentheses is ambiguous.</source>
+        <translation>Szintaktikai hiba: kondicionálisok (-&gt;), bikondicionálisok (&lt;-&gt;) vagy kizáró vagy összefűzése záró zárójelek nélkül félreérthető.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Individual terms and variables must start with a lowercase letter (a-z) or number.</source>
+        <translation>Szintaktikai hiba: az egyedi termeknek és változóknak kisbetűvel (a-z) vagy számmal kell kezdődniük.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Invalid characters in symbol name or empty argument parentheses &apos;()&apos;.</source>
+        <translation>Szintaktikai hiba: érvénytelen karakterek a szimbólum nevében, vagy üres argumentumzárójelek „()”.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Mismatched parentheses. Check opening and closing brackets.</source>
+        <translation>Szintaktikai hiba: nem megfelelő zárójelezés. Ellenőrizze a nyitó és záró zárójeleket.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Predicate or propositional variable names must start with an uppercase letter (A-Z).</source>
+        <translation>Szintaktikai hiba: a predikátum- vagy ítéletváltozók nevének nagybetűvel (A-Z) kell kezdődnie.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: The sentence has syntactical errors.</source>
+        <translation>Szintaktikai hiba: a formula szintaktikai hibákat tartalmaz.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Unrecognized or invalid logical connective symbol.</source>
+        <translation>Szintaktikai hiba: ismeretlen vagy érvénytelen logikai kötőjel-szimbólum.</translation>
+    </message>
+    <message>
+        <source>Syntax Error: Unrecognized or invalid quantifier symbol.</source>
+        <translation>Szintaktikai hiba: ismeretlen vagy érvénytelen kvantorszimbólum.</translation>
+    </message>
+    <message>
+        <source>The conclusion must contain an XOR.</source>
+        <translation>A konklúziónak kizáró vagy-t kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>The conclusion must have an identity predicate.</source>
+        <translation>A konklúziónak identitáspredikátumot kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>The conclusion must start with a universal.</source>
+        <translation>A konklúziónak univerzális kvantorral kell kezdődnie.</translation>
+    </message>
+    <message>
+        <source>The connective must be a conjunction or disjunction.</source>
+        <translation>A kötőjelnek konjunkciónak vagy diszjunkciónak kell lennie.</translation>
+    </message>
+    <message>
+        <source>The difference must be a bound variable.</source>
+        <translation>A különbségnek kötött változónak kell lennie.</translation>
+    </message>
+    <message>
+        <source>The difference must be a quantifier.</source>
+        <translation>A különbségnek kvantornak kell lennie.</translation>
+    </message>
+    <message>
+        <source>The final argument of the sequence&apos;s function must be the variable.</source>
+        <translation>A sorozat függvényének utolsó argumentumának a változónak kell lennie.</translation>
+    </message>
+    <message>
+        <source>The first argument must be a value function.</source>
+        <translation>Az első argumentumnak értékfüggvénynek kell lennie.</translation>
+    </message>
+    <message>
+        <source>The left disjunct must be the negation of the right disjunct.</source>
+        <translation>A bal diszjunktumnak a jobb diszjunktum tagadásának kell lennie.</translation>
+    </message>
+    <message>
+        <source>The left disjunct must have a negation.</source>
+        <translation>A bal diszjunktumnak tagadást kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>The minor premise and conclusion do not match the XOR disjuncts correctly.</source>
+        <translation>A kispremissza és a konklúzió nem egyezik megfelelően a kizáró vagy diszjunktumaival.</translation>
+    </message>
+    <message>
+        <source>The negation sentence must be negating either a conjunction or a disjunction.</source>
+        <translation>A tagadó formulának vagy egy konjunkciót, vagy egy diszjunkciót kell tagadnia.</translation>
+    </message>
+    <message>
+        <source>The new variable did not appear in the conclusion.</source>
+        <translation>Az új változó nem szerepelt a konklúzióban.</translation>
+    </message>
+    <message>
+        <source>The quantifiers must be the same.</source>
+        <translation>A kvantoroknak meg kell egyezniük.</translation>
+    </message>
+    <message>
+        <source>The reference must be the first disjunct in the conclusion.</source>
+        <translation>A hivatkozásnak a konklúzió első diszjunktumának kell lennie.</translation>
+    </message>
+    <message>
+        <source>The rest of the sentences must be the same.</source>
+        <translation>A formulák többi részének meg kell egyeznie.</translation>
+    </message>
+    <message>
+        <source>The second part must be the negation of the first.</source>
+        <translation>A második résznek az első tagadásának kell lennie.</translation>
+    </message>
+    <message>
+        <source>The sequence must only be used once.</source>
+        <translation>A sorozatot csak egyszer szabad használni.</translation>
+    </message>
+    <message>
+        <source>The sequence variable must not have been used before.</source>
+        <translation>A sorozatváltozót korábban nem szabad használni.</translation>
+    </message>
+    <message>
+        <source>The top connective must change between sentences.</source>
+        <translation>A legfelső kötőjelnek meg kell változnia a formulák között.</translation>
+    </message>
+    <message>
+        <source>The two arguments to the identity predicate must be the same.</source>
+        <translation>Az identitáspredikátum két argumentumának meg kell egyeznie.</translation>
+    </message>
+    <message>
+        <source>The two connectives must be complementary to one another.</source>
+        <translation>A két kötőjelnek egymás komplementerének kell lennie.</translation>
+    </message>
+    <message>
+        <source>The two references must match the two disjuncts of the XOR conclusion.</source>
+        <translation>A két hivatkozásnak egyeznie kell a kizáró vagy konklúzió két diszjunktumával.</translation>
+    </message>
+    <message>
+        <source>The two sentences must be of different lengths.</source>
+        <translation>A két formulának eltérő hosszúságúnak kell lennie.</translation>
+    </message>
+    <message>
+        <source>The variable must be the second argument of the value function.</source>
+        <translation>A változónak az értékfüggvény második argumentumának kell lennie.</translation>
+    </message>
+    <message>
+        <source>The variable must be used only twice.</source>
+        <translation>A változót csak kétszer szabad használni.</translation>
+    </message>
+    <message>
+        <source>The variables must not appear in the scope.</source>
+        <translation>A változók nem fordulhatnak elő a hatókörben.</translation>
+    </message>
+    <message>
+        <source>There must be a biconditional in one sentence.</source>
+        <translation>Az egyik formulának bikondicionálist kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a conditional in both sentences.</source>
+        <translation>Mindkét formulának kondicionálist kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a conditional in the conclusion.</source>
+        <translation>A konklúziónak kondicionálist kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction in the conclusion.</source>
+        <translation>A konklúziónak konjunkciót kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction in the reference.</source>
+        <translation>A hivatkozásnak konjunkciót kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction or a disjunction at the difference.</source>
+        <translation>A különbség helyén konjunkciónak vagy diszjunkciónak kell lennie.</translation>
+    </message>
+    <message>
+        <source>There must be a conjunction or a disjunction in one sentence.</source>
+        <translation>Az egyik formulának konjunkciót vagy diszjunkciót kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a connective at the difference.</source>
+        <translation>A különbség helyén kötőjelnek kell lennie.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in both sentences.</source>
+        <translation>Mindkét formulának kötőjelet kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in one sentence.</source>
+        <translation>Az egyik formulának kötőjelet kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a connective in the longer sentence.</source>
+        <translation>A hosszabb formulának kötőjelet kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a disjunction in the conclusion.</source>
+        <translation>A konklúziónak diszjunkciót kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a disjunction in the longest reference.</source>
+        <translation>A leghosszabb hivatkozásnak diszjunkciót kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a negated symbol in one sentence.</source>
+        <translation>Az egyik formulának tagadott szimbólumot kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a negation at the difference.</source>
+        <translation>A különbség helyén tagadásnak kell lennie.</translation>
+    </message>
+    <message>
+        <source>There must be a negation in one sentence.</source>
+        <translation>Az egyik formulának tagadást kell tartalmaznia.</translation>
+    </message>
+    <message>
+        <source>There must be a quantifier after the negation.</source>
+        <translation>A tagadás után kvantornak kell következnie.</translation>
+    </message>
+    <message>
+        <source>There must be a quantifier at the difference.</source>
+        <translation>A különbség helyén kvantornak kell lennie.</translation>
+    </message>
+    <message>
+        <source>There must be a tautology or a contradiction in the generalities.</source>
+        <translation>Az általánosságokban tautológiának vagy ellentmondásnak kell lennie.</translation>
+    </message>
+    <message>
+        <source>There must be a tautology or a contradiction within the difference.</source>
+        <translation>A különbségen belül tautológiának vagy ellentmondásnak kell lennie.</translation>
+    </message>
+    <message>
+        <source>There must be a universal at the beginning of the conclusion.</source>
+        <translation>A konklúzió elején univerzális kvantornak kell állnia.</translation>
+    </message>
+    <message>
+        <source>There must be an identity predicate in the scope.</source>
+        <translation>A hatókörben identitáspredikátumnak kell lennie.</translation>
+    </message>
+    <message>
+        <source>There must be connectives on both sentences.</source>
+        <translation>Mindkét formulának tartalmaznia kell kötőjeleket.</translation>
+    </message>
+    <message>
+        <source>There must be generalities at the difference.</source>
+        <translation>A különbség helyén általánosságoknak kell lenniük.</translation>
+    </message>
+    <message>
+        <source>There must be generalities in the scope.</source>
+        <translation>A hatókörben általánosságoknak kell lenniük.</translation>
+    </message>
+    <message>
+        <source>There must be more than one generality for distribution.</source>
+        <translation>A disztributivitáshoz egynél több általánosságnak kell lennie.</translation>
+    </message>
+    <message>
+        <source>There must be only two connected parts.</source>
+        <translation>Csak két összekapcsolt résznek szabad lennie.</translation>
+    </message>
+    <message>
+        <source>There must be only two parts for distribution.</source>
+        <translation>A disztributivitáshoz csak két résznek szabad lennie.</translation>
+    </message>
+    <message>
+        <source>There must be quantifiers at the difference.</source>
+        <translation>A különbség helyén kvantoroknak kell lenniük.</translation>
+    </message>
+    <message>
+        <source>Universal Generalization Error: The generalized variable must be arbitrary (not introduced by Existential Instantiation or unclosed assumptions).</source>
+        <translation>Univerzális általánosítás hiba: az általánosított változónak tetszőlegesnek kell lennie (nem egzisztenciális specifikáció vagy le nem zárt feltevés vezette be).</translation>
+    </message>
+    <message>
+        <source>Universal Generalization constructed incorrectly.</source>
+        <translation>Az univerzális általánosítás hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Universal Generalization requires exactly one (1) reference.</source>
+        <translation>Az univerzális általánosítás pontosan egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>Universal Instantiation constructed incorrectly.</source>
+        <translation>Az univerzális specifikáció hibásan lett felépítve.</translation>
+    </message>
+    <message>
+        <source>Universal Instantiation requires exactly one (1) reference.</source>
+        <translation>Az univerzális specifikáció pontosan egy (1) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>XOR Elimination requires exactly two (2) references.</source>
+        <translation>A kizáró vagy elhagyása pontosan két (2) hivatkozást igényel.</translation>
+    </message>
+    <message>
+        <source>XOR Introduction requires exactly two (2) references.</source>
+        <translation>A kizáró vagy eleje pontosan két (2) hivatkozást igényel.</translation>
     </message>
 </context>
 </TS>

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -82,7 +82,7 @@ ApplicationWindow {
         fileExists = false
         fileModified = false
         filename = "Untitled"
-        cConnector.evalText = "Evaluate Proof"
+        cConnector.evalText = qsTr("Evaluate Proof")
         proofModel.clearErrors()
 
         if (goalDialogID.opened)
@@ -106,7 +106,7 @@ ApplicationWindow {
 
     function startImportFlow(mode) {
         importMode = mode
-        cConnector.evalText = "Evaluate Proof"
+        cConnector.evalText = qsTr("Evaluate Proof")
         proofModel.clearErrors()
         isExtFile = true
         importBehaviorID.close()
@@ -180,16 +180,16 @@ ApplicationWindow {
     footer: Label {
         height: statusID.implicitHeight + 10
         leftPadding: 12
-        visible: !(cConnector.evalText === "Correct!"
-                   || cConnector.evalText === "Evaluate Proof")
+        visible: !(cConnector.evalText === qsTr("Correct!")
+                   || cConnector.evalText === qsTr("Evaluate Proof"))
 
         Text {
             id: statusID
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
             anchors.leftMargin: 12
-            text: cConnector.evalText === "Errors found"
-                  ? "⚠ Errors found — see inline details above each failing line."
+            text: cConnector.evalText === qsTr("Errors found")
+                  ? "⚠ " + qsTr("Errors found — see inline details above each failing line.")
                   : cConnector.evalText
             color: darkMode ? "#CF6679" : "red"
             font.pointSize: thefont.pointSize + 1
@@ -297,7 +297,7 @@ ApplicationWindow {
             // Called at the very start of smartPaste() — mark proof as
             // coming from an external source so the UI renders ref numbers.
             isExtFile = true
-            cConnector.evalText = "Evaluate Proof"
+            cConnector.evalText = qsTr("Evaluate Proof")
             proofModel.clearErrors()
         }
 
@@ -987,7 +987,7 @@ ApplicationWindow {
         sequence: "Ctrl+Shift+E" // Cmd+Shift+E on macOS — avoids Emacs "end-of-line" conflict
         context: Qt.ApplicationShortcut
         onActivated: {
-            cConnector.evalText = "Evaluate Proof"
+            cConnector.evalText = qsTr("Evaluate Proof")
             cConnector.evalProof(theData, theGoals, proofModel)
             goalDataID.evalGoals(theGoals, cConnector)
         }

--- a/qt/proofdata.cpp
+++ b/qt/proofdata.cpp
@@ -20,7 +20,7 @@
 ProofData::ProofData(QObject *parent)
     : QObject{parent}
 {
-    m_proofLines.append({1,"","premise",false,false,false,0,{-1},NULL});
+    m_proofLines.append({1,"","premise",false,false,false,0,{-1},QString()});
 }
 
 QVector<ProofLine> ProofData::lines() const
@@ -54,8 +54,9 @@ bool ProofData::setLineAt(int index, const ProofLine &proofLine)
 // Set sd->file for a line (required for rule lemma i.e. import proof)
 void ProofData::setFile(int index, const QString &name)
 {
-    m_proofLines[index].fname = (unsigned char *) calloc(name.size()+1, sizeof(unsigned char));
-    memcpy(m_proofLines[index].fname, name.toStdString().c_str(), name.size());
+    if (index < 0 || index >= m_proofLines.size())
+        return;
+    m_proofLines[index].fname = name;
 }
 
 // Insert a proof line (in m_proofLines) at a valid index
@@ -72,7 +73,7 @@ void ProofData::insertLine(int index,int a, QString b, QString c, bool d, bool e
     aLine.pSubEnd = f;
     aLine.pInd = g;
     aLine.pRefs = h;
-    aLine.fname = NULL;
+    aLine.fname = QString();
     aLine.pErrorMsg = QString();  // always start with no error
     aLine.pRuleCategory = cat;
     aLine.pRuleIndex = idx;

--- a/qt/proofdata.h
+++ b/qt/proofdata.h
@@ -29,7 +29,7 @@ struct ProofLine{
     bool pSubEnd;
     int pInd;
     QList<int> pRefs;
-    unsigned char *fname;
+    QString fname;       // value type: safe to copy through QVector<ProofLine>
     QString pErrorMsg;   // inline error text, empty = no error
 
     // Locale-invariant combo-box position.  -1 means structural / not a rule.

--- a/qt/settings.cpp
+++ b/qt/settings.cpp
@@ -5,10 +5,8 @@
 Settings::Settings(QGuiApplication *app)
     : m_app(app)
 {
-    // Add localization
-    QTranslator translator;
-    if (translator.load(QLocale::system(), u"aris-qt"_qs,u"_"_qs, u":/i18n"_qs)) {
-        app->installTranslator(&translator);
+    if (m_translator.load(QLocale::system(), u"aris-qt"_qs,u"_"_qs, u":/i18n"_qs)) {
+        app->installTranslator(&m_translator);
     }
 }
 

--- a/src/aio.c
+++ b/src/aio.c
@@ -774,6 +774,19 @@ aio_validate_proof (proof_t * proof)
  *  output:
  *    the opened proof, or NULL on error.
  */
+// Every early-out below used the file-wide XML_ERR(), which just reports
+// and returns -- leaking the partially-built `proof` (and any sen_data /
+// goal buffers already inserted into it) and the open `xml` reader on every
+// parse failure. Shadow it for the body of this function only so each of
+// those early-outs also releases what's been allocated so far; restored to
+// the original definition right after the function.
+#undef XML_ERR
+#define XML_ERR(r) { \
+    fprintf (stderr, "XML Error\n"); \
+    if (xml) xmlFreeTextReader (xml); \
+    if (proof) proof_destroy (proof); \
+    return r; \
+}
 proof_t *
 aio_open (const char * file_name)
 {
@@ -873,7 +886,7 @@ aio_open (const char * file_name)
                 item_t * ret_itm;
                 ret_itm = ls_push_obj (proof->goals, buffer);
                 if (!ret_itm)
-                    return NULL;
+                    XML_ERR (NULL);
             }
             else if (!strcmp ((const char *) buffer, GOAL_TAG))
             {
@@ -923,13 +936,13 @@ aio_open (const char * file_name)
 
             sd = aio_open_prem (xml);
             if (!sd)
-                return NULL;
+                XML_ERR (NULL);
             sd->line_num = line++;
 
             item_t * itm;
             itm = ls_push_obj (proof->everything, sd);
             if (!itm)
-                return NULL;
+                XML_ERR (NULL);
         }
         else if (!strcmp ((const char *) buffer, PREMISE_TAG))
         {
@@ -992,7 +1005,12 @@ aio_open (const char * file_name)
                 XML_ERR (NULL);
 
             int sub = 0, old_depth;
-            old_depth = ((sen_data *) proof->everything->tail->value)->depth;
+            // proof->everything->tail is NULL when there were no premise
+            // lines before this conclusion (a proof with zero premises is
+            // legal) -- fall back to depth 0 instead of dereferencing NULL.
+            old_depth = proof->everything->tail
+                ? ((sen_data *) proof->everything->tail->value)->depth
+                : 0;
             if (sd->depth > old_depth)
                 sub = 1;
 
@@ -1002,17 +1020,21 @@ aio_open (const char * file_name)
             item_t * itm;
             itm = ls_push_obj (proof->everything, sd);
             if (!itm)
-                return NULL;
+                XML_ERR (NULL);
         }
     }
 
     xmlFreeTextReader (xml);
+    xml = NULL;   // so the XML_ERR shadow below doesn't double-free it
 
     if (aio_compute_indices (proof) < 0)
         XML_ERR (NULL);
-        
+
     if (aio_validate_proof (proof) < 0)
         XML_ERR (NULL);
 
     return proof;
 }
+// Restore the file-wide definition for every other function below.
+#undef XML_ERR
+#define XML_ERR(r) {fprintf (stderr, "XML Error\n"); return r;}

--- a/src/aris.c
+++ b/src/aris.c
@@ -769,8 +769,10 @@ a conclusion must be specified in evaluation mode.\n");
           if (c_ret == -1)
             exit (EXIT_FAILURE);
 
+          // proof_destroy() now frees the proof_t struct itself as part of
+          // fully owning cleanup (see PRODUCTION_READINESS_AUDIT.md #10) --
+          // this used to be a required second free(), now it would double-free.
           proof_destroy (proof[c]);
-          free (proof[c]);
         }
 
       exit (EXIT_SUCCESS);

--- a/src/proof.c
+++ b/src/proof.c
@@ -59,6 +59,8 @@ proof_destroy (proof_t * proof)
     {
         item_t * n_itm;
         n_itm = itm->next;
+        if (itm->value)
+            sen_data_destroy ((sen_data *) itm->value);
         free (itm);
         itm = n_itm;
     }
@@ -68,8 +70,20 @@ proof_destroy (proof_t * proof)
         item_t * n_itm;
         n_itm = itm->next;
         free (itm->value);
+        free (itm);
         itm = n_itm;
     }
+
+    // destroy_list() only frees the item_t wrappers (already done above) and
+    // the list_t header itself -- it does not touch item->value, which is
+    // exactly what we want here since the payloads were just freed above.
+    proof->everything->head = proof->everything->tail = NULL;
+    destroy_list (proof->everything);
+
+    proof->goals->head = proof->goals->tail = NULL;
+    destroy_list (proof->goals);
+
+    free (proof);
 }
 
 /* Evaluates a proof object.
@@ -229,7 +243,7 @@ convert_proof_latex (proof_t * proof, const char * filename)
     if (!file)
     {
         PERROR (NULL);
-        exit (EXIT_FAILURE);
+        return AEC_MEM;
     }
 
     fprintf (file, "\\documentclass{article}\n");

--- a/src/rules-table.c
+++ b/src/rules-table.c
@@ -585,6 +585,7 @@ rules_table_destroy_menu_item (sentence * sen)
 
   if (sen->proof)
     proof_destroy (sen->proof);
+  sen->proof = NULL;   // proof_destroy() now frees the struct itself; avoid a dangling field
   free (SD(sen)->file);
   SD(sen)->file = NULL;
 

--- a/src/sen-data.c
+++ b/src/sen-data.c
@@ -629,7 +629,8 @@ convert_sd_latex (sen_data * sd)
 
     text = sd->text;
 
-    out_str = (char *) calloc (sd->depth * 6 + 1, sizeof (char));
+    // "\pquad " is 7 characters; must match the per-depth allocation below.
+    out_str = (char *) calloc (sd->depth * 7 + 1, sizeof (char));
     CHECK_ALLOC (out_str, NULL);
 
     out_pos = 0;

--- a/src/sexpr-process-quant.c
+++ b/src/sexpr-process-quant.c
@@ -459,6 +459,7 @@ proc_nq (unsigned char * prem, unsigned char * conc)
     if (!scope)
         return NULL;
 
+    int var_len = strlen ((char *) var);
     free (var);
 
     int gqv;
@@ -483,7 +484,7 @@ proc_nq (unsigned char * prem, unsigned char * conc)
     unsigned char * oth_sen;
     int oth_pos, alloc_size;
 
-    alloc_size = l_len - strlen (var) - S_CL - 5;
+    alloc_size = l_len - var_len - S_CL - 5;
     oth_sen = (unsigned char *) calloc (alloc_size + 1, sizeof (char));
     CHECK_ALLOC (oth_sen, NULL);
 

--- a/src/sexpr-process.c
+++ b/src/sexpr-process.c
@@ -202,11 +202,27 @@ construct_other (unsigned char * main_str,
 {
     unsigned char * oth_sen;
     int oth_pos = init_pos;
-    va_list args;
+    va_list args, args_copy;
 
     va_start (args, template);
 
-    oth_sen = (unsigned char *) calloc (alloc_size + 1, sizeof (char));
+    // alloc_size is a hand-derived estimate computed by each caller (e.g.
+    // l_len - 2 * strlen (lsen) - S_NL - 7 in proc_bn) that has to exactly
+    // match init_pos + formatted-length + tail-length. At least one caller
+    // gets this wrong and undersizes the buffer -- caught as a heap buffer
+    // overflow under glibc's _FORTIFY_SOURCE, silent memory corruption
+    // elsewhere. Measure the real formatted length instead of trusting it;
+    // every call site passes a single "%s" arg, so va_copy + vsnprintf(NULL,
+    // 0, ...) gives the exact size needed regardless of what alloc_size says.
+    va_copy (args_copy, args);
+    int fmt_len = vsnprintf (NULL, 0, template, args_copy);
+    va_end (args_copy);
+
+    int tail_len = strlen (main_str + fin_pos);
+    int needed = init_pos + fmt_len + tail_len + 1;
+    (void) alloc_size;   // superseded by the exact size computed above
+
+    oth_sen = (unsigned char *) calloc (needed, sizeof (char));
     CHECK_ALLOC (oth_sen, NULL);
     strncpy (oth_sen, main_str, oth_pos);
 
@@ -250,7 +266,13 @@ sexpr_add_not (unsigned char * in_str)
 {
     unsigned char * not_in_str;
 
-    not_in_str = (unsigned char *) calloc (strlen (in_str) + S_NL + 3, sizeof (char));
+    // "(%s %s)" with args S_NOT and in_str needs strlen(in_str) + S_NL
+    // (the two %s substitutions) + 3 literal characters ('(', ' ', ')')
+    // + 1 for the null terminator = + 4, not + 3. The previous off-by-one
+    // undersized the buffer by exactly the null terminator's byte -- a
+    // heap buffer overflow on every call, caught by glibc's
+    // _FORTIFY_SOURCE (see PRODUCTION_READINESS_AUDIT.md).
+    not_in_str = (unsigned char *) calloc (strlen (in_str) + S_NL + 4, sizeof (char));
     CHECK_ALLOC (not_in_str, NULL);
     sprintf (not_in_str, "(%s %s)", S_NOT, in_str);
 


### PR DESCRIPTION
- Added i18n support for error messages (French, Hungarian, Arabic, German)
- Fixed PDF export formatting for subproofs and UI chevron slot alignment
- Fixed a use-after-free bug in proc_nq
- Full audit and fix pass across the Qt/WASM frontend and proof engine: heap
  overflows, wrong Boolean-proof validation, crash/UB bugs, and memory leaks,
  plus wired the existing `doc/proofs` regression suite into CI